### PR TITLE
Removes access restrictions from Outpost First Aid Station.

### DIFF
--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -1208,7 +1208,7 @@
 "xl" = (/obj/structure/table/glass,/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)
 "xm" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/obj/structure/bed/chair,/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)
 "xn" = (/obj/structure/sign/greencross{desc = "White cross in a green field, you can get medical aid here."; name = "First-Aid"},/turf/simulated/wall/r_wall,/area/surface/outpost/research/xenoresearch)
-"xo" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/glass_medical,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)
+"xo" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/glass_medical{name = "Outpost First Aid Station"; req_one_access = newlist()},/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)
 "xp" = (/obj/machinery/space_heater,/obj/structure/extinguisher_cabinet{pixel_x = -25},/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)
 "xq" = (/obj/machinery/light,/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)
 "xr" = (/obj/machinery/camera/network/research_outpost{c_tag = "OPR - Research Hallway 3"; dir = 1},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/white,/area/surface/outpost/research/xenoresearch)


### PR DESCRIPTION
:warning: Not to be confused with the SAR Prep Area; the first-aid station is in xenobio/xenoflora.

:cl: EvilJackCarver
:wrench: Removes access restrictions from the first aid station on the outpost.
/:cl:

This should have been part of #190 but I forgot about this particular medical station.