### PR TITLE
Start Now only starts if the round is ready

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -57,6 +57,8 @@ GLOBAL_VAR_INIT(CURRENT_TICKLIMIT, TICK_LIMIT_RUNNING)
 	var/map_loading = FALSE	//Are we loading in a new map?
 
 	var/current_runlevel	//for scheduling different subsystems for different stages of the round
+	
+	var/pending_start = FALSE		//Eclipse edit: Do we have a pending start request?
 
 	var/static/restart_clear = 0
 	var/static/restart_timeout = 0
@@ -191,6 +193,12 @@ GLOBAL_VAR_INIT(CURRENT_TICKLIMIT, TICK_LIMIT_RUNNING)
 
 	if (!current_runlevel)
 		SetRunLevel(RUNLEVEL_LOBBY)
+
+	// // // BEGIN ECLIPSE EDIT // // //
+	//"Start Now" should only start if we are safe to
+	if(pending_start)
+		ticker.pregame_timeleft = 1		//1 second, so it doesn't all go to shit as soon as everything comes online
+	// // // END ECLIPSE EDIT // // //
 
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -199,7 +199,6 @@ GLOBAL_VAR_INIT(CURRENT_TICKLIMIT, TICK_LIMIT_RUNNING)
 	if(pending_start)
 		ticker.pregame_timeleft = 1		//1 second, so it doesn't all go to shit as soon as everything comes online
 	// // // END ECLIPSE EDIT // // //
-
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -874,6 +874,18 @@ var/datum/announcement/minor/admin_min_announcer = new
 		alert("Unable to start the game as it is not set up.")
 		return
 	if(ticker.current_state == GAME_STATE_PREGAME)
+		// // // BEGIN ECLIPSE EDIT // // //
+		//"Start Now" should only start if we are safe to
+		if(!Master.current_runlevel)
+			Master.pending_start = !(Master.pending_start)		//simple toggle.
+			if(Master.pending_start)		//if pending start
+				log_admin("[usr.key] tried to start the game, but initialisations were not finished. Start pending.")
+				message_admins("<font color='blue'>[usr.key] tried to start the game, but initialisations were not finished. The round will start as soon as possible.</font>")
+			else			//no pending start, so it was cancelled.
+				log_admin("[usr.key] has cancelled a pending start.")
+				message_admins("<font color='blue'>[usr.key] has cancelled a pending start. Game will start as normal.</font>")
+			return 1		//implied else
+		// // // END ECLIPSE EDIT // // //
 		ticker.current_state = GAME_STATE_SETTING_UP
 		Master.SetRunLevel(RUNLEVEL_SETUP)
 		log_admin("[usr.key] has started the game.")


### PR DESCRIPTION
:cl: EvilJackCarver
🛠 The "Start Now" admin verb will now only start the round if the initializations are complete (with a 1 second delay).
/:cl:

This is a draft for now (for Travis checks), gotta let it run and check stability when I get home.

CLOSES #197 AS FIXED

![](https://cdn.discordapp.com/attachments/365348657970544650/568900579124969482/unknown.png)