### PR TITLE
Adds an Eclipse-specific configuration file, tweaks whitelist checks

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -1,7 +1,5 @@
 var/datum/controller/transfer_controller/transfer_controller
 
-#define NUMBER_OF_VOTE_EXTENSIONS 2
-
 datum/controller/transfer_controller
 	var/timerbuffer = 0 //buffer for time check
 	var/currenttick = 0
@@ -9,7 +7,7 @@ datum/controller/transfer_controller
 	var/shift_last_vote = 0 //Citadel Edit
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
-	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * NUMBER_OF_VOTE_EXTENSIONS) //VOREStation Edit //Change this "1" to how many extend votes you want there to be.
+	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * config.vote_extensions) //VOREStation Edit //Change this "1" to how many extend votes you want there to be.
 	shift_last_vote = shift_hard_end - config.vote_autotransfer_interval //VOREStation Edit
 	processing_objects += src
 
@@ -21,7 +19,7 @@ datum/controller/transfer_controller/proc/process()
 	//VOREStation Edit START
 	if (round_duration_in_ticks >= shift_last_vote - 2 MINUTES)
 		shift_last_vote = 999999999999 //Setting to a stupidly high number since it'll be not used again.
-		to_world("<b>Warning: This upcoming round-extend vote will be your [NUMBER_OF_VOTE_EXTENSIONS > 1 ? "FINAL" : "ONLY"] extend vote. Wrap up your scenes in the next 60 minutes if the round is extended.</b>") //VOREStation Edit //Eclipse Edit: "FINAL" or "ONLY" depending on final or only.
+		to_world("<b>Warning: This upcoming round-extend vote will be your [config.vote_extensions > 1 ? "FINAL" : "ONLY"] extend vote. Wrap up your scenes in the next 60 minutes if the round is extended.</b>") //VOREStation Edit //Eclipse Edit: "FINAL" or "ONLY" depending on final or only.
 	if (round_duration_in_ticks >= shift_hard_end - 1 MINUTE)
 		init_shift_change(null, 1)
 		shift_hard_end = timerbuffer + config.vote_autotransfer_interval //If shuttle somehow gets recalled, let's force it to call again next time a vote would occur.

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -57,7 +57,7 @@
 			if("use_job_whitelisting")
 				config.usejobwhitelist = TRUE
 			if("admins_restricted_by_whitelist")
-				config.wl_admins_too = true
+				config.wl_admins_too = TRUE
 			if("vote_extensions")
 				config.vote_extensions = value as num
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -59,5 +59,5 @@
 			if("admins_restricted_by_whitelist")
 				config.wl_admins_too = TRUE
 			if("vote_extensions")
-				config.vote_extensions = value as num
+				config.vote_extensions = value
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -11,9 +11,6 @@
 	// Job Whitelisting
 	var/usejobwhitelist = FALSE				//Job whitelisting enable
 	var/wl_admins_too = FALSE				//Admins go through the whitelist too?
-	var/wl_head_roles = FALSE				//Whitelist head roles?
-	var/wl_silicons = FALSE					//Whitelist silicons?
-	var/wl_security = FALSE					//Whitelist security?
 
 	//Miscellaneous
 	var/vote_extensions = 2
@@ -61,12 +58,6 @@
 				config.usejobwhitelist = TRUE
 			if("admins_restricted_by_whitelist")
 				config.whitelist_admins_too = true
-			if("wl_head_roles_restricted")
-				config.wl_head_roles = TRUE
-			if("wl_silicons_restricted")
-				config.wl_silicons = TRUE
-			if("wl_security_restricted")
-				config.wl_security = TRUE
 			if("vote_extensions")
 				config.vote_extensions = value as num
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -9,6 +9,7 @@
 	var/shift_end_horn_global = TRUE		//Play to everyone or just spawned characters?
 	
 	//Miscellaneous
+	var/vote_extensions = 2
 	var/tip_of_the_round = FALSE			//Tip of the Round
 	var/force_reginald = FALSE				//Force spawn Reginald.
 	var/usejobwhitelist = FALSE				//Job whitelisting
@@ -50,4 +51,6 @@
 				config.tip_of_the_round = TRUE
 			if("use_job_whitelisting")
 				config.usejobwhitelist = TRUE
+			if("vote_extensions")
+				config.vote_extensions = value as num
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -11,11 +11,14 @@
 	var/shift_end_horn_global = TRUE		//Play to everyone or just spawned characters?
 
 	// Job Whitelisting
-	var/usejobwhitelist = FALSE				//Job whitelisting enable
+	var/usejobwhitelist = FALSE				//Master job whitelisting enable
+	var/wl_heads = FALSE					//Whitelist Heads of Staff?
+	var/wl_security = FALSE					//Whitelist Security department?
+	var/wl_silicons = FALSE					//Whitelist silicons?
 	var/wl_admins_too = FALSE				//Admins go through the whitelist too?
 
 	//Miscellaneous
-	var/vote_extensions = 2					//Number of vote extensions.
+	var/vote_extensions = 2
 	var/tip_of_the_round = FALSE			//Tip of the Round
 	var/force_reginald = FALSE				//Force spawn Reginald.
 
@@ -58,6 +61,12 @@
 				config.tip_of_the_round = TRUE
 			if("use_job_whitelisting")
 				config.usejobwhitelist = TRUE
+			if("whitelist_heads")
+				config.wl_heads = TRUE
+			if("whitelist_security")
+				config.wl_security = TRUE
+			if("whitelist_silicons")
+				config.wl_silicons = TRUE
 			if("admins_restricted_by_whitelist")
 				config.wl_admins_too = TRUE
 			if("vote_extensions")

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -7,12 +7,20 @@
 	var/shift_end_horn = FALSE				//Master Enable
 	var/shift_end_horn_delay = 48			//Delay, in 1/10 sec
 	var/shift_end_horn_global = TRUE		//Play to everyone or just spawned characters?
-	
+
+	// Job Whitelisting
+	var/usejobwhitelist = FALSE				//Job whitelisting enable
+	var/wl_admins_too = FALSE				//Admins go through the whitelist too?
+	var/wl_head_roles = FALSE				//Whitelist head roles?
+	var/wl_silicons = FALSE					//Whitelist silicons?
+	var/wl_security = FALSE					//Whitelist security?
+
 	//Miscellaneous
 	var/vote_extensions = 2
 	var/tip_of_the_round = FALSE			//Tip of the Round
 	var/force_reginald = FALSE				//Force spawn Reginald.
-	var/usejobwhitelist = FALSE				//Job whitelisting
+
+	
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")
@@ -51,6 +59,14 @@
 				config.tip_of_the_round = TRUE
 			if("use_job_whitelisting")
 				config.usejobwhitelist = TRUE
+			if("admins_restricted_by_whitelist")
+				config.whitelist_admins_too = true
+			if("wl_head_roles_restricted")
+				config.wl_head_roles = TRUE
+			if("wl_silicons_restricted")
+				config.wl_silicons = TRUE
+			if("wl_security_restricted")
+				config.wl_security = TRUE
 			if("vote_extensions")
 				config.vote_extensions = value as num
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -3,6 +3,8 @@
 //
 
 /datum/configuration
+	var/eclipse_config_loaded = FALSE		//for things that require this, such as Reginald force spawning
+	
 	// Shift End Horn
 	var/shift_end_horn = FALSE				//Master Enable
 	var/shift_end_horn_delay = 48			//Delay, in 1/10 sec
@@ -13,7 +15,7 @@
 	var/wl_admins_too = FALSE				//Admins go through the whitelist too?
 
 	//Miscellaneous
-	var/vote_extensions = 2
+	var/vote_extensions = 2					//Number of vote extensions.
 	var/tip_of_the_round = FALSE			//Tip of the Round
 	var/force_reginald = FALSE				//Force spawn Reginald.
 
@@ -60,4 +62,6 @@
 				config.wl_admins_too = TRUE
 			if("vote_extensions")
 				config.vote_extensions = value
+	
+	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -1,0 +1,53 @@
+//
+// Eclipse-specific configuration and config values
+//
+
+/datum/configuration
+	// Shift End Horn
+	var/shift_end_horn = FALSE				//Master Enable
+	var/shift_end_horn_delay = 48			//Delay, in 1/10 sec
+	var/shift_end_horn_global = TRUE		//Play to everyone or just spawned characters?
+	
+	//Miscellaneous
+	var/tip_of_the_round = FALSE			//Tip of the Round
+	var/force_reginald = FALSE				//Force spawn Reginald.
+	var/usejobwhitelist = FALSE				//Job whitelisting
+
+/hook/startup/proc/read_eclipse_config()
+	var/list/Lines = file2list("config/config_eclipse.txt")
+	for(var/t in Lines)
+		if(!t)	continue
+
+		t = trim(t)
+		if (length(t) == 0)
+			continue
+		else if (copytext(t, 1, 2) == "#")
+			continue
+
+		var/pos = findtext(t, " ")
+		var/name = null
+		var/value = null
+
+		if (pos)
+			name = lowertext(copytext(t, 1, pos))
+			value = copytext(t, pos + 1)
+		else
+			name = lowertext(t)
+
+		if (!name)
+			continue
+
+		switch (name)
+			if ("enable_shift_horn")
+				config.shift_end_horn = TRUE
+			if("shift_horn_delay")
+				config.shift_end_horn_delay = 10 * value
+			if("shift_horn_for_spawned_players_only")
+				config.shift_end_horn_global = FALSE
+			if("force_spawn_reginald")
+				config.force_reginald = TRUE
+			if("enable_totr")
+				config.tip_of_the_round = TRUE
+			if("use_job_whitelisting")
+				config.usejobwhitelist = TRUE
+	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -57,7 +57,7 @@
 			if("use_job_whitelisting")
 				config.usejobwhitelist = TRUE
 			if("admins_restricted_by_whitelist")
-				config.whitelist_admins_too = true
+				config.wl_admins_too = true
 			if("vote_extensions")
 				config.vote_extensions = value as num
 	return 1

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -114,7 +114,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	// // // BEGIN ECLIPSE EDIT // // //
 	world.log << "Scheduled crew transfer has begun."		//let the guy in the console see it
 	if(config.shift_end_horn && !horn_has_fired)
-		spawn(config.shift_end_horn_delay)		//1 mile at speed of sound in air at 0C, 1 bar pressure = 4.8574... seconds. This assumes the colony is at 1 mile away, and the horn is originating from there.
+		spawn(config.shift_end_horn_delay)
 			blow_horn()
 
 /datum/emergency_shuttle_controller/proc/blow_horn()

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -23,9 +23,9 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 	var/datum/announcement/priority/emergency_shuttle_recalled = new(0, new_sound = sound('sound/AI/shuttlerecalled.ogg'))
 
 	// Eclipse added vars
-	var/shift_change_horn = TRUE		//Should we have a shift-change horn when the shuttle gets called?
 	var/shift_change_horn_file = 'sound/items/AirHorn.ogg'
 	var/shift_change_horn_volume = 10
+	var/horn_has_fired = FALSE
 
 /datum/emergency_shuttle_controller/New()
 	escape_pods = list()
@@ -113,13 +113,19 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 
 	// // // BEGIN ECLIPSE EDIT // // //
 	world.log << "Scheduled crew transfer has begun."		//let the guy in the console see it
-	if(shift_change_horn)
-		spawn(48)		//1 mile at speed of sound in air at 0C, 1 bar pressure = 4.8574... seconds. This assumes the colony is at 1 mile away, and the horn is originating from there.
+	if(config.shift_end_horn && !horn_has_fired)
+		spawn(config.shift_end_horn_delay)		//1 mile at speed of sound in air at 0C, 1 bar pressure = 4.8574... seconds. This assumes the colony is at 1 mile away, and the horn is originating from there.
 			blow_horn()
 
 /datum/emergency_shuttle_controller/proc/blow_horn()
-	world << sound(shift_change_horn_file, repeat = 0, wait = 0, volume = shift_change_horn_volume, channel = 3)
-	shift_change_horn = FALSE
+	if(config.shift_end_horn_global)
+		world << sound(shift_change_horn_file, repeat = 0, wait = 0, volume = shift_change_horn_volume, channel = 3)
+	else
+		for(var/mob/M in player_list)
+			if(!istype(M,/mob/new_player) && !isdeaf(M))
+				M << sound(shift_change_horn_file, repeat = 0, wait = 0, volume = shift_change_horn_volume, channel = 3)
+
+	horn_has_fired = TRUE
 	// // // END ECLIPSE EDIT // // //
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -62,7 +62,7 @@ var/global/datum/controller/gameticker/ticker
 						sleep(1)
 
 			// // // ECLIPSE EDIT: Tip of the Round // // //
-			if((pregame_timeleft <= send_tip_at) && !tip_sent)		//it's time to send a tip
+			if(config.tip_of_the_round && (pregame_timeleft <= send_tip_at) && !tip_sent)		//it's time to send a tip
 				send_tip_of_the_round()
 			// // // END ECLIPSE EDIT: Tip of the Round // // //
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -17,7 +17,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 	economic_modifier = 20
-	whitelist_only = config.wl_head_roles			//Eclipse Edit: Config Option
+	whitelist_only = 1
 	
 	minimum_character_age = 25
 	ideal_character_age = 70 // Old geezer captains ftw
@@ -49,7 +49,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	req_admin_notify = 1
 	minimal_player_age = 10
 	economic_modifier = 10
-	whitelist_only = config.wl_head_roles			//Eclipse Edit: Config Option
+	whitelist_only = 1
 	
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -17,7 +17,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 	economic_modifier = 20
-	whitelist_only = 1
+	whitelist_only = config.wl_head_roles			//Eclipse Edit: Config Option
 	
 	minimum_character_age = 25
 	ideal_character_age = 70 // Old geezer captains ftw
@@ -49,7 +49,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	req_admin_notify = 1
 	minimal_player_age = 10
 	economic_modifier = 10
-	whitelist_only = 1
+	whitelist_only = config.wl_head_roles			//Eclipse Edit: Config Option
 	
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -17,7 +17,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 14
 	economic_modifier = 20
-	whitelist_only = 1
+	wl_config_heads = TRUE			//Eclipse edit: Config-based whitelisting.
 	
 	minimum_character_age = 25
 	ideal_character_age = 70 // Old geezer captains ftw
@@ -49,7 +49,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	req_admin_notify = 1
 	minimal_player_age = 10
 	economic_modifier = 10
-	whitelist_only = 1
+	wl_config_heads = TRUE			//Eclipse edit: Config-based whitelisting.
 	
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -68,6 +68,7 @@
 	economic_modifier = 5
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station)
+	wl_config_heads = FALSE		//Eclipse edit: Redundancy - QM is not a head of staff and will never be one.
 
 	ideal_character_age = 40
 

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/engineering/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = config.wl_head_roles		//Eclipse Edit: Config option.
+	whitelist_only = 1
 
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -13,6 +13,7 @@
 	req_admin_notify = 1
 	economic_modifier = 10
 	whitelist_only = 1
+	wl_config_heads = 1
 
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -12,8 +12,7 @@
 	idtype = /obj/item/weapon/card/id/engineering/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = 1
-	wl_config_heads = 1
+	wl_config_heads = TRUE		//Eclipse edit: config-based whitelisting
 
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/engineering/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = 1
+	whitelist_only = config.wl_head_roles		//Eclipse Edit: Config option.
 
 	minimum_character_age = 25
 	ideal_character_age = 50

--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -7,6 +7,18 @@
 
 	//Every hour playing this role gains this much time off. (Can be negative for off duty jobs!)
 	var/timeoff_factor = 3
+	
+	// // // BEGIN ECLIPSE ADDITIONS // // //
+	//Rationale: Config-based job whitelisting.
+	
+	//Is this job whitelisted based on config files?
+	var/wl_config_heads = FALSE		//heads of staff
+	var/wl_config_sec = FALSE		//security
+	var/wl_config_borgs = FALSE		//silicons
+	
+	//Is this job intended for admins only?
+	var/wl_admin_only = FALSE
+	// // // END ECLIPSE ADDITIONS
 
 // Check client-specific availability rules.
 /datum/job/proc/player_has_enough_pto(client/C)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/medical/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = 1
+	whitelist_only = config.wl_head_roles		//Eclipse Edit: Config option.
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/medical/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = 1
+	wl_config_heads = TRUE			//Eclipse edit: Config-based whitelisting.
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/medical/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = config.wl_head_roles		//Eclipse Edit: Config option.
+	whitelist_only = 1
 
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,8 +12,8 @@
 	idtype = /obj/item/weapon/card/id/science/head
 	req_admin_notify = 1
 	economic_modifier = 15
-	whitelist_only = 1
-
+	wl_config_heads = TRUE			//Eclipse edit: Config-based whitelisting.
+	
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/science/head
 	req_admin_notify = 1
 	economic_modifier = 15
-	whitelist_only = 1
+	whitelist_only = config.wl_head_roles		//Eclipse edit: config option.
 
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/science/head
 	req_admin_notify = 1
 	economic_modifier = 15
-	whitelist_only = config.wl_head_roles		//Eclipse edit: config option.
+	whitelist_only = 1
 
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
 			            access_tox_storage, access_teleporter, access_sec_doors,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/security/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = (config.wl_head_roles || config.wl_security)		//Eclipse edit: Config option
+	whitelist_only = 1
 	
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
@@ -44,7 +44,6 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 5
 	outfit_type = /decl/hierarchy/outfit/job/security/warden
-	whitelist_only =  config.wl_security		//Eclipse edit: Config option
 
 /datum/job/detective
 	title = "Detective"
@@ -63,7 +62,6 @@
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	alt_titles = list("Forensic Technician" = /decl/hierarchy/outfit/job/security/detective/forensic, "Investigator")
-	whitelist_only =  config.wl_security		//Eclipse edit: Config option
 
 /datum/job/officer
 	title = "Security Officer"
@@ -82,4 +80,3 @@
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
 	alt_titles = list("Junior Officer")
-	whitelist_only =  config.wl_security		//Eclipse edit: Config option

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -12,7 +12,7 @@
 	idtype = /obj/item/weapon/card/id/security/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = 1
+	whitelist_only = (config.wl_head_roles || config.wl_security)		//Eclipse edit: Config option
 	
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
@@ -44,6 +44,7 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 5
 	outfit_type = /decl/hierarchy/outfit/job/security/warden
+	whitelist_only =  config.wl_security		//Eclipse edit: Config option
 
 /datum/job/detective
 	title = "Detective"
@@ -62,6 +63,7 @@
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	alt_titles = list("Forensic Technician" = /decl/hierarchy/outfit/job/security/detective/forensic, "Investigator")
+	whitelist_only =  config.wl_security		//Eclipse edit: Config option
 
 /datum/job/officer
 	title = "Security Officer"
@@ -80,3 +82,4 @@
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
 	alt_titles = list("Junior Officer")
+	whitelist_only =  config.wl_security		//Eclipse edit: Config option

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -12,7 +12,8 @@
 	idtype = /obj/item/weapon/card/id/security/head
 	req_admin_notify = 1
 	economic_modifier = 10
-	whitelist_only = 1
+	wl_config_heads = TRUE			//Eclipse edit: Config-based whitelisting.
+	wl_config_sec = TRUE			//Eclipse edit: Config-based whitelisting.
 	
 	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
@@ -44,6 +45,7 @@
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_external_airlocks)
 	minimal_player_age = 5
 	outfit_type = /decl/hierarchy/outfit/job/security/warden
+	wl_config_sec = TRUE			//Eclipse edit: Config-based whitelisting.
 
 /datum/job/detective
 	title = "Detective"
@@ -62,6 +64,7 @@
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/detective
 	alt_titles = list("Forensic Technician" = /decl/hierarchy/outfit/job/security/detective/forensic, "Investigator")
+	wl_config_sec = TRUE			//Eclipse edit: Config-based whitelisting.
 
 /datum/job/officer
 	title = "Security Officer"
@@ -80,3 +83,4 @@
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/security/officer
 	alt_titles = list("Junior Officer")
+	wl_config_sec = TRUE			//Eclipse edit: Config-based whitelisting.

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -11,6 +11,7 @@
 	minimal_player_age = 7
 	account_allowed = 0
 	economic_modifier = 0
+	whitelist_only = config.wl_silicons		//Eclipse Edit: Config option.
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
@@ -45,6 +46,7 @@
 	alt_titles = list("Robot", "Drone")
 	account_allowed = 0
 	economic_modifier = 0
+	whitelist_only = config.wl_silicons		//Eclipse Edit: Config option.
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -11,7 +11,6 @@
 	minimal_player_age = 7
 	account_allowed = 0
 	economic_modifier = 0
-	whitelist_only = config.wl_silicons		//Eclipse Edit: Config option.
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
@@ -46,7 +45,6 @@
 	alt_titles = list("Robot", "Drone")
 	account_allowed = 0
 	economic_modifier = 0
-	whitelist_only = config.wl_silicons		//Eclipse Edit: Config option.
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -11,6 +11,7 @@
 	minimal_player_age = 7
 	account_allowed = 0
 	economic_modifier = 0
+	wl_config_borgs = TRUE			//Eclipse edit: Config-based whitelisting.
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
@@ -45,6 +46,7 @@
 	alt_titles = list("Robot", "Drone")
 	account_allowed = 0
 	economic_modifier = 0
+	wl_config_borgs = TRUE			//Eclipse edit: Config-based whitelisting.
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0

--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -14,6 +14,7 @@
 	economic_modifier = 20
 	whitelist_only = 1
 	latejoin_only = 1
+	wl_admin_only = TRUE			//Eclipse edit: admin only
 
 	minimum_character_age = 25
 	ideal_character_age = 40
@@ -56,6 +57,7 @@
 	economic_modifier = 20
 	whitelist_only = 1
 	latejoin_only = 1
+	wl_admin_only = TRUE			//Eclipse edit: admin only
 
 	minimum_character_age = 25
 	ideal_character_age = 40

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -24,6 +24,15 @@ var/global/datum/controller/occupations/job_master
 			var/datum/job/job = new J()
 			if(!job)	continue
 			if(job.faction != faction)	continue
+			// // // BEGIN ECLIPSE EDITS // // //
+			//Whitelist job based on configuration files.
+			if(job.wl_config_heads && config.wl_heads)		//Heads of Staff
+				job.whitelist_only = TRUE
+			if(job.wl_config_sec && config.wl_security)		//Security
+				job.whitelist_only = TRUE
+			if(job.wl_config_borgs && config.wl_silicons)		//Silicons
+				job.whitelist_only = TRUE
+			// // // END ECLIPSE EDITS // // //
 			occupations += job
 		sortTim(occupations, /proc/cmp_job_datums)
 

--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -15,7 +15,7 @@ var/list/job_whitelist = list()
 	var/datum/job/job = job_master.GetJob(rank)
 	// // // BEGIN ECLIPSE EDIT // // //
 	// Allows config option to disable job restrictions. Allows admins to bypass
-	if(check_rights(R_ADMIN, 0, M))		//They're admin
+	if(!config.wl_admins_too && check_rights(R_ADMIN, 0, M))		//They're admins.
 		return 1
 	if(!config.usejobwhitelist)			//Whitelist disabled.
 		return 1

--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -19,13 +19,17 @@ var/list/job_whitelist = list()
 		return 1
 	if(!config.usejobwhitelist)			//Whitelist disabled.
 		return 1
+	if(job.wl_admin_only && check_rights(R_ADMIN, 0, M))		//Admin only ranks
+		return 1
 	// // // END ECLIPSE EDIT // // //
 	if(!job.whitelist_only)
 		return 1
 	if(rank == USELESS_JOB) //VOREStation Edit - Visitor not Assistant
 		return 1
+	/* Eclipse Removal - moved above in the edit
 	if(check_rights(R_ADMIN, 0))
 		return 1
+	*/
 	if(!job_whitelist)
 		return 0
 	if(M && rank)

--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -13,6 +13,13 @@ var/list/job_whitelist = list()
 
 /proc/is_job_whitelisted(mob/M, var/rank)
 	var/datum/job/job = job_master.GetJob(rank)
+	// // // BEGIN ECLIPSE EDIT // // //
+	// Allows config option to disable job restrictions. Allows admins to bypass
+	if(check_rights(R_ADMIN, 0, M))		//They're admin
+		return 1
+	if(!config.usejobwhitelist)			//Whitelist disabled.
+		return 1
+	// // // END ECLIPSE EDIT // // //
 	if(!job.whitelist_only)
 		return 1
 	if(rank == USELESS_JOB) //VOREStation Edit - Visitor not Assistant

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -1,4 +1,4 @@
-## Eclipse specific configurations, for downstream servers.
+## Eclipse specific configurations, for downstream servers and dev environments.
 
 #########
 # SHIFT END HORN
@@ -35,6 +35,21 @@ USE_JOB_WHITELISTING
 ## Uncomment to require them to be whitelisted.
 #ADMINS_RESTRICTED_BY_WHITELIST
 
+## WHITELIST HEADS OF STAFF
+## Should heads of staff be whitelisted?
+## Uncomment to whitelist.
+WHITELIST_HEADS
+
+## WHITELIST SECURITY DEPARTMENT
+## Should the Security department be whitelisted?
+## Uncomment to whitelist.
+#WHITELIST_SECURITY
+
+## WHITELIST AI/CYBORG
+## Should silicons be whitelisted? This will not affect pAIs, only AI and borgs.
+## Uncomment to whitelist.
+#WHITELIST_SILICONS
+
 #########
 # MISCELLANY
 #########
@@ -43,9 +58,6 @@ USE_JOB_WHITELISTING
 ## How many votes for round extensions should players have?
 ## Default is 2 votes.
 VOTE_EXTENSIONS 2
-
-## JOB WHITELISTS
-## Uses the jobwhitelist.txt file to whitelist 
 
 ## REGINALD DATE CHECK OVERRIDE
 ## Forces Reginald to spawn, regardless of the day of week.

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -1,0 +1,35 @@
+## Eclipse specific configurations, for downstream servers.
+
+######### SHIFT END HORN
+
+## MASTER ENABLE
+## Comment to disable the shift change horn.
+ENABLE_SHIFT_HORN
+
+## HORN DELAY
+## How long should the shift end horn wait (after the proc clears) to blow the horn?
+## Default is 4.8 seconds (1 mile at 20 deg C, 1013 mbar ambient pressure).
+## Unit: Seconds
+SHIFT_HORN_DELAY 4.8
+
+## GLOBAL DISABLE
+## Uncomment this line to make the shift end horn only audible to players spawned
+## in-game or observing, not players on the lobby screen.
+#SHIFT_HORN_FOR_SPAWNED_PLAYERS_ONLY
+
+######### MISCELLANY
+
+## JOB WHITELISTS
+## Uses the jobwhitelist.txt file to whitelist specific jobs.
+## Comment to disable.
+USE_JOB_WHITELISTING
+
+## REGINALD DATE CHECK OVERRIDE
+## Forces Reginald to spawn, regardless of the day of week.
+## Uncomment to enable.
+#FORCE_SPAWN_REGINALD
+
+## TIPS OF THE ROUND
+## Should tips of the round be shown?
+## Comment to disable.
+ENABLE_TOTR

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -35,21 +35,6 @@ USE_JOB_WHITELISTING
 ## Uncomment to require them to be whitelisted.
 #ADMINS_RESTRICTED_BY_WHITELIST
 
-## HEAD ROLES RESTRICTIONS
-## Should head roles be restricted by whitelist?
-## Uncomment to enable restrictions.
-WL_HEAD_ROLES_RESTRICTED
-
-## SILICON RESTRICTIONS
-## Should AI and cyborgs be restricted by whitelist?
-## Uncomment to enable restrictions.
-#WL_SILICONS_RESTRICTED
-
-## SECURITY RESTRICTIONS
-## Should Security department jobs be restricted by whitelist?
-## Uncomment to enable restrictions.
-#WL_SECURITY_RESTRICTED
-
 #########
 # MISCELLANY
 #########

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -12,12 +12,17 @@ ENABLE_SHIFT_HORN
 ## Unit: Seconds
 SHIFT_HORN_DELAY 4.8
 
-## GLOBAL DISABLE
+## GLOBAL AUDIO DISABLE
 ## Uncomment this line to make the shift end horn only audible to players spawned
 ## in-game or observing, not players on the lobby screen.
 #SHIFT_HORN_FOR_SPAWNED_PLAYERS_ONLY
 
 ######### MISCELLANY
+
+## VOTE EXTENSIONS
+## How many votes for round extensions should players have?
+## Default is 2 votes.
+VOTE_EXTENSIONS 2
 
 ## JOB WHITELISTS
 ## Uses the jobwhitelist.txt file to whitelist specific jobs.

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -1,6 +1,8 @@
 ## Eclipse specific configurations, for downstream servers.
 
-######### SHIFT END HORN
+#########
+# SHIFT END HORN
+#########
 
 ## MASTER ENABLE
 ## Comment to disable the shift change horn.
@@ -17,7 +19,40 @@ SHIFT_HORN_DELAY 4.8
 ## in-game or observing, not players on the lobby screen.
 #SHIFT_HORN_FOR_SPAWNED_PLAYERS_ONLY
 
-######### MISCELLANY
+#########
+# WHITELISTING
+#########
+
+## MASTER ENABLE
+## Uses the jobwhitelist.txt file to whitelist specific jobs.
+## Comment to disable.
+USE_JOB_WHITELISTING
+
+## INCLUDE ADMINS
+## Should admins be required to be whitelisted as a job in order to play it? 
+## This will not stop them from spawning in a character using the admin tools,
+## only the game preferences.
+## Uncomment to require them to be whitelisted.
+#ADMINS_RESTRICTED_BY_WHITELIST
+
+## HEAD ROLES RESTRICTIONS
+## Should head roles be restricted by whitelist?
+## Uncomment to enable restrictions.
+WL_HEAD_ROLES_RESTRICTED
+
+## SILICON RESTRICTIONS
+## Should AI and cyborgs be restricted by whitelist?
+## Uncomment to enable restrictions.
+#WL_SILICONS_RESTRICTED
+
+## SECURITY RESTRICTIONS
+## Should Security department jobs be restricted by whitelist?
+## Uncomment to enable restrictions.
+#WL_SECURITY_RESTRICTED
+
+#########
+# MISCELLANY
+#########
 
 ## VOTE EXTENSIONS
 ## How many votes for round extensions should players have?
@@ -25,9 +60,7 @@ SHIFT_HORN_DELAY 4.8
 VOTE_EXTENSIONS 2
 
 ## JOB WHITELISTS
-## Uses the jobwhitelist.txt file to whitelist specific jobs.
-## Comment to disable.
-USE_JOB_WHITELISTING
+## Uses the jobwhitelist.txt file to whitelist 
 
 ## REGINALD DATE CHECK OVERRIDE
 ## Forces Reginald to spawn, regardless of the day of week.

--- a/eclipsestation.dme
+++ b/eclipsestation.dme
@@ -201,6 +201,7 @@
 #include "code\controllers\autotransfer.dm"
 #include "code\controllers\communications.dm"
 #include "code\controllers\configuration.dm"
+#include "code\controllers\configuration_eclipse.dm"
 #include "code\controllers\configuration_vr.dm"
 #include "code\controllers\controller.dm"
 #include "code\controllers\emergency_shuttle_controller.dm"

--- a/modular_eclipse/code/modules/admin/verbs/totr.dm
+++ b/modular_eclipse/code/modules/admin/verbs/totr.dm
@@ -46,8 +46,8 @@
 
 	ticker.chosen_tip = input
 
-	// If we've already tipped, then send it straight away.
-	if(ticker.tip_sent)
+	// If we've already tipped, or if tips are disabled, then send it straight away.
+	if(ticker.tip_sent || !config.tip_of_the_round)
 		ticker.send_tip_of_the_round()
 
 

--- a/modular_eclipse/reginald/reginald.dm
+++ b/modular_eclipse/reginald/reginald.dm
@@ -26,7 +26,7 @@
 	. = ..()
 	
 	if(config.force_reginald)
-		desc = "It's Reginald. He's here every day this week."
+		desc = "It's Reginald. He's putting in some overtime right now."
 	else
 		if(time2text(world.timeofday, "Day") == "Tuesday")
 			desc = "Everybody say 'Hi, Reginald'. But remember, he's only here on alternating Tuesdays."

--- a/modular_eclipse/reginald/reginald.dm
+++ b/modular_eclipse/reginald/reginald.dm
@@ -43,10 +43,12 @@
 
 /obj/effect/landmark/reginald_spawner/New()
 //If the debug override above is true, we want to spawn it. No ifs, ands, or buts.
+	while(!config.eclipse_config_loaded)		//wait for config to be loaded, first, so we know if we need to force spawn Reginald.
+		sleep(5)
 	if(config.force_reginald)
 		new /mob/living/simple_animal/crab/reginald(src.loc)
 		log_debug("Reginald force-spawned.")
-		log_to_dd("Reginald force-spawned: Debug define set at compile time.")
+		log_to_dd("Reginald force-spawned: Debug option set in config.")
 		message_admins("Reginald was force-spawned at ([src.loc.x], [src.loc.y], [src.loc.z]): Debug option set in config.")
 		delete_me = TRUE
 		return		//Implied 'else'.
@@ -61,19 +63,24 @@
 			if(time2text(world.timeofday, "Day") == "Tuesday")
 				new /mob/living/simple_animal/crab/reginald(src.loc)
 				log_debug("Spawning Reginald...")
+				log_to_dd("Spawning Reginald...")
 			else
 				log_debug("Week 1, but not a Tuesday. Reginald not spawning.")
+				log_to_dd("Week 1, but not a Tuesday. Reginald not spawning.")
 		// Week 3.
 		if(15 to 21)
 			if(time2text(world.timeofday, "Day") == "Tuesday")
 				new /mob/living/simple_animal/crab/reginald(src.loc)
 				log_debug("Spawning Reginald...")
+				log_to_dd("Spawning Reginald...")
 			else
 				log_debug("Week 3, but not a Tuesday. Reginald not spawning.")
+				log_to_dd("Week 3, but not a Tuesday. Reginald not spawning.")
 //There are up to 5 Tuesdays in a month. To ensure maximum alternation, Reginald
 //does not appear the last week of the month.
 		else
 			log_debug("Not first or third week. Reginald not spawning.")
+			log_to_dd("Not first or third week. Reginald not spawning.")
 		
 	delete_me = TRUE
 	return

--- a/modular_eclipse/reginald/reginald.dm
+++ b/modular_eclipse/reginald/reginald.dm
@@ -13,9 +13,6 @@
  * -Spitzer
  */
 
-//Debug mode override.
-#define OVERRIDE_DATE_CHECK 0
-
 // .../code/modules/mob/living/simple_animal/animals/crab.dm
 // Some Discord jokes just go too far. This is one of them.
 
@@ -28,8 +25,8 @@
 /mob/living/simple_animal/crab/reginald/New()
 	. = ..()
 	
-	if(OVERRIDE_DATE_CHECK)
-		desc = "It's Reginald. Yell at a coder that his date check is overridden."
+	if(config.force_reginald)
+		desc = "It's Reginald. He's here every day this week."
 	else
 		if(time2text(world.timeofday, "Day") == "Tuesday")
 			desc = "Everybody say 'Hi, Reginald'. But remember, he's only here on alternating Tuesdays."
@@ -46,11 +43,11 @@
 
 /obj/effect/landmark/reginald_spawner/New()
 //If the debug override above is true, we want to spawn it. No ifs, ands, or buts.
-	if(OVERRIDE_DATE_CHECK)
+	if(config.force_reginald)
 		new /mob/living/simple_animal/crab/reginald(src.loc)
 		log_debug("Reginald force-spawned.")
 		log_to_dd("Reginald force-spawned: Debug define set at compile time.")
-		message_admins("Reginald was force-spawned at ([src.loc.x], [src.loc.y], [src.loc.z]): Debug define set at compile time.")
+		message_admins("Reginald was force-spawned at ([src.loc.x], [src.loc.y], [src.loc.z]): Debug option set in config.")
 		delete_me = TRUE
 		return		//Implied 'else'.
 
@@ -80,7 +77,3 @@
 		
 	delete_me = TRUE
 	return
-
-#if OVERRIDE_DATE_CHECK
-	#warning Overriding date check on Reginald for testing. This should not be compiled for production with this enabled...
-#endif


### PR DESCRIPTION
:cl: EvilJackCarver
➕ Adds an Eclipse-specific configuration file, to allow downstreams and devs to do their own stuff.
➕ Heads of Staff, Security, and Silicons are now whitelist-restricted or not based on config options.
🛠 Job-related whitelisting no longer restricts admin staff (defined as staff with the R_ADMIN right) from joining as a particular job, if it's enabled in the config options.
/:cl:

~~Untested, about to check it.~~ Tested as of latest commit review comment