### PR TITLE
Mice can now chew wires.

### DIFF
--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -23,7 +23,8 @@
 	var/force_reginald = FALSE				//Force spawn Reginald.
 	var/mice_wires = FALSE					//Mice can eat wires
 	var/mice_wire_chance = 5				//Chance for a mouse to eat wires on the turf it's on.
-	var/mice_wire_cooldown = 3000			//Coioldown for mouse wire chewing
+	var/mice_wire_cooldown = 6000			//Cooldown for mouse wire chewing
+	var/mice_wire_cooldown_rs = FALSE		//Roundstart mouse wire cooldown.
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")
@@ -78,6 +79,8 @@
 				config.mice_wire_chance = text2num(value)
 			if("mice_wire_cooldown")
 				config.mice_wire_cooldown = 10 * text2num(value)
+			if("roundstart_mouse_wire_cooldown")
+				config.mice_wire_cooldown_rs = TRUE
 	
 	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -21,8 +21,8 @@
 	var/vote_extensions = 2
 	var/tip_of_the_round = FALSE			//Tip of the Round
 	var/force_reginald = FALSE				//Force spawn Reginald.
-
-	
+	var/mice_wires = FALSE					//Mice can eat wires
+	var/mice_wire_chance = 5				//Chance for a mouse to eat wires on the turf it's on.
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")
@@ -71,6 +71,10 @@
 				config.wl_admins_too = TRUE
 			if("vote_extensions")
 				config.vote_extensions = value
+			if("mice_eat_wires")
+				config.mice_wires = TRUE
+			if("mice_wire_chomp_chance")
+				config.mice_wire_chance = value
 	
 	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -16,15 +16,19 @@
 	var/wl_security = FALSE					//Whitelist Security department?
 	var/wl_silicons = FALSE					//Whitelist silicons?
 	var/wl_admins_too = FALSE				//Admins go through the whitelist too?
+	
+	//Mice and wires
+	var/mice_wires = FALSE					//Mice can eat wires
+	var/mice_wire_chance = 5				//Chance for a mouse to eat wires on the turf it's on.
+	var/mice_wire_cooldown = 6000			//Cooldown for mouse wire chewing
+	var/mice_wire_cooldown_rs = FALSE		//Roundstart mouse wire cooldown.
+	var/mice_wire_eng_req = FALSE			//Require engineers to chew wires?
 
 	//Miscellaneous
 	var/vote_extensions = 2
 	var/tip_of_the_round = FALSE			//Tip of the Round
 	var/force_reginald = FALSE				//Force spawn Reginald.
-	var/mice_wires = FALSE					//Mice can eat wires
-	var/mice_wire_chance = 5				//Chance for a mouse to eat wires on the turf it's on.
-	var/mice_wire_cooldown = 6000			//Cooldown for mouse wire chewing
-	var/mice_wire_cooldown_rs = FALSE		//Roundstart mouse wire cooldown.
+
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")
@@ -81,6 +85,8 @@
 				config.mice_wire_cooldown = 10 * text2num(value)
 			if("roundstart_mouse_wire_cooldown")
 				config.mice_wire_cooldown_rs = TRUE
+			if("mice_require_engineers")
+				config.mice_wire_eng_req = TRUE
 	
 	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -23,6 +23,7 @@
 	var/force_reginald = FALSE				//Force spawn Reginald.
 	var/mice_wires = FALSE					//Mice can eat wires
 	var/mice_wire_chance = 5				//Chance for a mouse to eat wires on the turf it's on.
+	var/mice_wire_cooldown = 3000			//Coioldown for mouse wire chewing
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")
@@ -75,6 +76,8 @@
 				config.mice_wires = TRUE
 			if("mice_wire_chomp_chance")
 				config.mice_wire_chance = text2num(value)
+			if("mice_wire_cooldown")
+				config.mice_wire_cooldown = 10 * text2num(value)
 	
 	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -52,7 +52,7 @@
 			if ("enable_shift_horn")
 				config.shift_end_horn = TRUE
 			if("shift_horn_delay")
-				config.shift_end_horn_delay = 10 * value
+				config.shift_end_horn_delay = 10 * text2num(value)
 			if("shift_horn_for_spawned_players_only")
 				config.shift_end_horn_global = FALSE
 			if("force_spawn_reginald")
@@ -70,11 +70,11 @@
 			if("admins_restricted_by_whitelist")
 				config.wl_admins_too = TRUE
 			if("vote_extensions")
-				config.vote_extensions = value
+				config.vote_extensions = text2num(value)
 			if("mice_eat_wires")
 				config.mice_wires = TRUE
 			if("mice_wire_chomp_chance")
-				config.mice_wire_chance = value
+				config.mice_wire_chance = text2num(value)
 	
 	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -142,20 +142,32 @@
 	
 	if(!config.mice_wires)		//If disabled by config, don't even bother.
 		return
-	var/turf/F = get_turf(src)
-	if(istype(F) && !F.is_plating())
+	var/turf/F = src.loc
+	if(istype(F) && F.is_plating())
 		var/obj/structure/cable/C = locate() in F
 		if(C && prob(config.mice_wire_chance))
+			var/start_loc = src.loc		//you can stop a mouse by pciking up thje... little ghuy. Yeah.
+		
+			var/chew_varb_start = pick("gnawing at","chewing up","biting into","eating at","nibbling at")		//diffiuculzt to taype while dtronk
+			var/chew_verb_finish = pick("bites into","gnaws into","eats through","nibbles into", "chews through")
+			
+			//add a vcooldown iwhenr youew so0ber
+			
+			visible_message("<span class='warning'>[src] begins [chew_varb_start] \the [C]...</span>")
+			sleep(2 SECONDS)		//sleetp tzwop secojnds to allw it zto cujhrew througvh
+			if(start_loc != src.loc)
+				return		//yayyyy you stiopped theh impeindign mouse timebiomb. The wiresy arte safe!
 			if(C.powernet.avail)
-				visible_message("<span class='warning'>[src] gnaws into the [C] and tenses up!</span>")
+				visible_message("<span class='warning'>[src] [chew_verb_finish] \the [C] and tenses up!</span>")
 				playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
-				electrocute_act(C.powernet, C)
+				death()
 			else
-				visible_message("<span class='warning'>[src] chews through the [C].</span>")
-
+				visible_message("<span class='warning'>[src] [chew_verb_finish] \the [C].</span>")
+			
+			//sdpawn th enew bables
 			if(C.d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
-				C = new/obj/item/stack/cable_coil(F, 2, C.color)
+				new/obj/item/stack/cable_coil(F, 2, C.color)
 			else
-				C = new/obj/item/stack/cable_coil(F, 1, C.color)
-			qdel(C)
-
+				new/obj/item/stack/cable_coil(F, 1, C.color)
+			C.investigate_log("was eaten by [src]/[usr ? usr : "no user"]/[ckey ? ckey : "no ckey"]","wires")		//admihn logghingggggggggggggg
+			C.Destroy()

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -141,9 +141,19 @@
 /mob/living/simple_animal/mouse/handle_wander_movement()
 	..()
 	
+	//check for engineers.
+	var/active_engineers
+	for(var/mob/M in player_list)
+		if(!M)
+			return		//Nobody's home. Go back to sleep.
+		if(M.mind.assigned_role in engineering_positions)
+			active_engineers++
+	
 	if(!config.mice_wires)		//If disabled by config, don't even bother.
 		return
 	if(ai_inactive)		//AI inactive, so no wire chewing.
+		return
+	if(config.mice_wire_eng_req && !active_engineers)
 		return
 	var/turf/F = src.loc
 	if(istype(F) && F.is_plating())
@@ -185,6 +195,15 @@
 			C.Destroy()
 
 /mob/living/simple_animal/mouse/proc/debug_wire()		//DEBUGGING!
+
+	//check for engineers.
+	var/active_engineers
+	var/no_players = FALSE
+	for(var/mob/M in player_list)
+		if(!M)
+			no_players = TRUE
+		if(M && M.mind.assigned_role in engineering_positions)
+			active_engineers++
 	to_chat(usr, "<span class='notice'>\
 	*-------Mouse wire debugging-------*<br>\
 	Name: [src]<br>\
@@ -192,6 +211,10 @@
 	Wire chewing:</span>")
 	if(!config.mice_wires)
 		to_chat(usr, "<span class='warning'>Cannot chew wires: Disabled by configuration.<br></span>")
+	else if(no_players)
+		to_chat(usr, "<span class='warning'>Cannot chew wires: No players present.<br></span>")
+	else if(config.mice_wire_eng_req && !active_engineers)
+		to_chat(usr, "<span class='warning'>Cannot chew wires: No engineering staff present.<br></span>")
 	else if(ai_inactive)
 		to_chat(usr, "<span class='warning'>Cannot chew wires: AI disabled.<br></span>")
 	else if(stat == DEAD)

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -191,17 +191,17 @@
 	Ref: \ref[src]<br><br>\
 	Wire chewing:</span>")
 	if(!config.mice_wires)
-		to_chat(usr, "<span class='warning'>Cannot chew wires: Disabled by configuration.</span>")
+		to_chat(usr, "<span class='warning'>Cannot chew wires: Disabled by configuration.<br></span>")
 	else if(ai_inactive)
-		to_chat(usr, "<span class='warning'>Cannot chew wires: AI disabled.</span>")
+		to_chat(usr, "<span class='warning'>Cannot chew wires: AI disabled.<br></span>")
 	else if(stat == DEAD)
-		to_chat(usr, "<span class='warning'>Cannot chew wires: Mob deceased.</span>")
+		to_chat(usr, "<span class='warning'>Cannot chew wires: Mob deceased.<br></span>")
 	else if((config.mice_wire_cooldown_rs || last_mouse_wire) && (world.time <= last_mouse_wire + config.mice_wire_cooldown))
-		to_chat(usr, "<span class='warning'>Cannot chew wires: Cooldown active.</span>")
+		to_chat(usr, "<span class='warning'>Cannot chew wires: Cooldown active.<br></span>")
 	else
-		to_chat(usr, "<span class='notice'><b>Can chew wires.</b></span>")
+		to_chat(usr, "<span class='notice'><b>Can chew wires.</b><br></span>")
 	to_chat(usr, "<span class='notice'>\
-	<br>*--Cooldown--*<br>\
+	*--Cooldown--*<br>\
 	Last chewed wire: [last_mouse_wire]<br>\
 	Current tick: [world.time]<br>\
 	Cooldown duration (ticks): [config.mice_wire_cooldown]<br></span>")

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -146,17 +146,18 @@
 	if(istype(F) && F.is_plating())
 		var/obj/structure/cable/C = locate() in F
 		if(C && prob(config.mice_wire_chance))
-			var/start_loc = src.loc		//you can stop a mouse by pciking up thje... little ghuy. Yeah.
+			var/start_loc = src.loc		//You can stop a mouse chewing through a wire by picking him up before he's done.
 		
-			var/chew_varb_start = pick("gnawing at","chewing up","biting into","eating at","nibbling at")		//diffiuculzt to taype while dtronk
+			//RANDOM WORDS! YAAAY.
+			var/chew_verb_start = pick("gnawing at","chewing up","biting into","eating at","nibbling at")
 			var/chew_verb_finish = pick("bites into","gnaws into","eats through","nibbles into", "chews through")
 			
-			//add a vcooldown iwhenr youew so0ber
+			//TODO TODO TODO: Add a global wire cooldown
 			
-			visible_message("<span class='warning'>[src] begins [chew_varb_start] \the [C]...</span>")
-			sleep(2 SECONDS)		//sleetp tzwop secojnds to allw it zto cujhrew througvh
+			visible_message("<span class='warning'>[src] begins [chew_verb_start] \the [C]...</span>")
+			sleep(2 SECONDS)		//sleep 2 seconds to allow it to chew through, and let players pick it up to disarm the impeding wire timebomb.
 			if(start_loc != src.loc)
-				return		//yayyyy you stiopped theh impeindign mouse timebiomb. The wiresy arte safe!
+				return		//yayyyy you stiopped theh impeindign mouse timebiomb. The wiresy arte safe!		//I'm keeping this drunken comment. ^Spitz
 			if(C.powernet.avail)
 				visible_message("<span class='warning'>[src] [chew_verb_finish] \the [C] and tenses up!</span>")
 				playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
@@ -164,10 +165,10 @@
 			else
 				visible_message("<span class='warning'>[src] [chew_verb_finish] \the [C].</span>")
 			
-			//sdpawn th enew bables
+			//spawn the cable where the mouse chewed through the other.
 			if(C.d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
 				new/obj/item/stack/cable_coil(F, 2, C.color)
 			else
 				new/obj/item/stack/cable_coil(F, 1, C.color)
-			C.investigate_log("was eaten by [src]/[usr ? usr : "no user"]/[ckey ? ckey : "no ckey"]","wires")		//admihn logghingggggggggggggg
+			C.investigate_log("was eaten by [src]/[usr ? usr : "no user"]/[ckey ? ckey : "no ckey"]","wires")		//admin logging, theoretically
 			C.Destroy()

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -135,3 +135,27 @@
 
 /mob/living/simple_animal/mouse/cannot_use_vents()
 	return
+
+// // // BEGIN ECLIPSE EDITS // // //
+/mob/living/simple_animal/mouse/handle_wander_movement()
+	..()
+	
+	if(!config.mice_wires)		//If disabled by config, don't even bother.
+		return
+	var/turf/F = get_turf(src)
+	if(istype(F) && !F.is_plating())
+		var/obj/structure/cable/C = locate() in F
+		if(C && prob(config.mice_wire_chance))
+			if(C.powernet.avail)
+				visible_message("<span class='warning'>[src] gnaws into the [C] and tenses up!</span>")
+				playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
+				electrocute_act(C.powernet, C)
+			else
+				visible_message("<span class='warning'>[src] chews through the [C].</span>")
+
+			if(C.d1)	// 0-X cables are 1 unit, X-X cables are 2 units long
+				C = new/obj/item/stack/cable_coil(F, 2, C.color)
+			else
+				C = new/obj/item/stack/cable_coil(F, 1, C.color)
+			qdel(C)
+

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -136,7 +136,8 @@
 /mob/living/simple_animal/mouse/cannot_use_vents()
 	return
 
-// // // BEGIN ECLIPSE EDITS // // //
+// // // BEGIN ECLIPSE EDIT // // //
+//Rationale: Mice can chew wires if enabled in config.
 /mob/living/simple_animal/mouse/handle_wander_movement()
 	..()
 	
@@ -152,12 +153,20 @@
 			var/chew_verb_start = pick("gnawing at","chewing up","biting into","eating at","nibbling at")
 			var/chew_verb_finish = pick("bites into","gnaws into","eats through","nibbles into", "chews through")
 			
-			//TODO TODO TODO: Add a global wire cooldown
-			
+			if(world.time <= last_mouse_wire + config.mice_wire_cooldown)		//If we're in cooldown, nope the fuck outta there.
+				return
 			visible_message("<span class='warning'>[src] begins [chew_verb_start] \the [C]...</span>")
 			sleep(2 SECONDS)		//sleep 2 seconds to allow it to chew through, and let players pick it up to disarm the impeding wire timebomb.
 			if(start_loc != src.loc)
 				return		//yayyyy you stiopped theh impeindign mouse timebiomb. The wiresy arte safe!		//I'm keeping this drunken comment. ^Spitz
+			
+			//HOLD ON THERE COWBOY! Before you hit copper, better make sure another mouse hasn't triggered the cooldown!
+			if(world.time <= last_mouse_wire + config.mice_wire_cooldown)		//If cooldown was triggered after the checks start, abort.
+				visible_message("<span class='warning'>[src] stops [chew_verb_start] \the [C] and looks around, as if some inkling of self-preservation suddenly kicked in.</span>")
+				return
+			
+			//Alright. Carry on then.
+			last_mouse_wire = world.time	//set cooldown
 			if(C.powernet.avail)
 				visible_message("<span class='warning'>[src] [chew_verb_finish] \the [C] and tenses up!</span>")
 				playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
@@ -172,3 +181,6 @@
 				new/obj/item/stack/cable_coil(F, 1, C.color)
 			C.investigate_log("was eaten by [src]/[usr ? usr : "no user"]/[ckey ? ckey : "no ckey"]","wires")		//admin logging, theoretically
 			C.Destroy()
+
+var/last_mouse_wire = 0			//this feels dirty.
+// // // END ECLIPSE EDIT // // //

--- a/code/modules/mob/living/simple_animal/animals/mouse.dm
+++ b/code/modules/mob/living/simple_animal/animals/mouse.dm
@@ -143,9 +143,11 @@
 	
 	//check for engineers.
 	var/active_engineers
-	for(var/mob/M in player_list)
+	for(var/mob/living/M in player_list)
 		if(!M)
 			return		//Nobody's home. Go back to sleep.
+		if(!M.mind)
+			continue
 		if(M.mind.assigned_role in engineering_positions)
 			active_engineers++
 	
@@ -198,12 +200,12 @@
 
 	//check for engineers.
 	var/active_engineers
-	var/no_players = FALSE
-	for(var/mob/M in player_list)
-		if(!M)
-			no_players = TRUE
-		if(M && M.mind.assigned_role in engineering_positions)
+	for(var/mob/living/M in player_list)
+		if(!M.mind)
+			continue
+		if(M.mind.assigned_role in engineering_positions)
 			active_engineers++
+
 	to_chat(usr, "<span class='notice'>\
 	*-------Mouse wire debugging-------*<br>\
 	Name: [src]<br>\
@@ -211,8 +213,6 @@
 	Wire chewing:</span>")
 	if(!config.mice_wires)
 		to_chat(usr, "<span class='warning'>Cannot chew wires: Disabled by configuration.<br></span>")
-	else if(no_players)
-		to_chat(usr, "<span class='warning'>Cannot chew wires: No players present.<br></span>")
 	else if(config.mice_wire_eng_req && !active_engineers)
 		to_chat(usr, "<span class='warning'>Cannot chew wires: No engineering staff present.<br></span>")
 	else if(ai_inactive)

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -81,6 +81,11 @@ MICE_WIRE_COOLDOWN 600
 ## Uncomment to enable.
 ROUNDSTART_MOUSE_WIRE_COOLDOWN
 
+## REQUIRE ENGINEERING
+## If enabled, mice will require engineering staff to be present in order to eat
+## the wires.
+MICE_REQUIRE_ENGINEERS
+
 #########
 # MISCELLANY
 #########

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -68,3 +68,15 @@ VOTE_EXTENSIONS 2
 ## Should tips of the round be shown?
 ## Comment to disable.
 ENABLE_TOTR
+
+## MOUSE WIRE EATING BEHAVIOURS
+## Should mice be able to eat wires? This will give Engineering a bit more to do
+## each shift, than 'set up engine, go to sleep'.
+## Uncomment to enable.
+#MICE_EAT_WIRES
+
+## MOUSE WIRE EATING CHANCE
+## If a mouse moves onto a wire tile, what're the odds it'll bite it?
+## Default is 5%
+## Units: Percentage
+MICE_WIRE_CHOMP_CHANCE 5

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -70,9 +70,16 @@ MICE_WIRE_CHOMP_CHANCE 5
 ## After a mouse eats a wire, how long should it wait before another mouse can
 ## chew up a wire elsewhere? This is intended as a hard limiter to prevent mice
 ## from obliterating the power grid too quickly.
-## Default is 300 seconds (5 minutes).
+## Default is 600 seconds (10 minutes).
 ## Units: Seconds
-MICE_WIRE_COOLDOWN 300
+MICE_WIRE_COOLDOWN 600
+
+## ROUNDSTART COOLDOWN
+## This will enable a roundstart cooldown so people can settle in before mice
+## become a problem. The cooldown is taken from the global cooldown, above.
+## WARNING: This does not account for the lobby timer!
+## Uncomment to enable.
+ROUNDSTART_MOUSE_WIRE_COOLDOWN
 
 #########
 # MISCELLANY

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -51,6 +51,30 @@ WHITELIST_HEADS
 #WHITELIST_SILICONS
 
 #########
+# MOUSE WIRE CHEWING
+#########
+
+## MASTER ENABLE
+## Should mice be able to eat wires? This will give Engineering a bit more to do
+## each shift, than 'set up engine, go to sleep'.
+## Uncomment to enable.
+#MICE_EAT_WIRES
+
+## CHANCE TO EAT
+## If a mouse moves onto a wire tile, what're the odds it'll bite it?
+## Default is 5%
+## Units: Percentage
+MICE_WIRE_CHOMP_CHANCE 5
+
+## GLOBAL COOLDOWN
+## After a mouse eats a wire, how long should it wait before another mouse can
+## chew up a wire elsewhere? This is intended as a hard limiter to prevent mice
+## from obliterating the power grid too quickly.
+## Default is 300 seconds (5 minutes).
+## Units: Seconds
+MICE_WIRE_COOLDOWN 300
+
+#########
 # MISCELLANY
 #########
 
@@ -68,15 +92,3 @@ VOTE_EXTENSIONS 2
 ## Should tips of the round be shown?
 ## Comment to disable.
 ENABLE_TOTR
-
-## MOUSE WIRE EATING BEHAVIOURS
-## Should mice be able to eat wires? This will give Engineering a bit more to do
-## each shift, than 'set up engine, go to sleep'.
-## Uncomment to enable.
-#MICE_EAT_WIRES
-
-## MOUSE WIRE EATING CHANCE
-## If a mouse moves onto a wire tile, what're the odds it'll bite it?
-## Default is 5%
-## Units: Percentage
-MICE_WIRE_CHOMP_CHANCE 5


### PR DESCRIPTION
:cl: EvilJackCarver
➕ Mice now have a chance to chew wires. This behaviour can be enabled via the config.
⚠️ Config updated.
/:cl:

This should give engineers something to do.

![Eclipse_Station_2019-05-31_02-53-55.png](https://user-images.githubusercontent.com/1784490/58691524-d1fb2e80-8351-11e9-92ba-87e27fb692d7.png)
>*That poor wire...*


---

# Config explanations

* MICE_EAT_WIRES
  * **Master enable**. If commented out, mice will not eat wires.

* MICE_WIRE_CHOMP_CHANCE *<int>* 
  * Chance for a mouse to chew a wire, after it moves. 
  * Units: percent
  * Default: 5

* MICE_WIRE_COOLDOWN *<int>* 
  * How long after a mouse chews through a wire can any other mouse (itself included, if it survived) chew through one. 
  * Units: seconds
  * Default: 600 (10 minutes)

* ROUNDSTART_MOUSE_WIRE_COOLDOWN
  * If commented out, mice will be able to eat wires at roundstart. Otherwise, mice will wait `MICE_WIRE_COOLDOWN` seconds before they can chew a wire.

---

# Debugging proc

Call `debug_wire()` on a mouse to see if they are capable of chewing wires.

### Output samples

#### Ready
![image](https://user-images.githubusercontent.com/1784490/58691579-01aa3680-8352-11e9-94ca-cf5774cd2d46.png)

#### Dead mouse
![image](https://user-images.githubusercontent.com/1784490/58691561-f48d4780-8351-11e9-82a9-20df38023972.png)