### PR TITLE
Removes telekinesis from the game.

### DIFF
--- a/code/_onclick/click_legacy.dm
+++ b/code/_onclick/click_legacy.dm
@@ -3,8 +3,8 @@
 	~Sayu
 */
 
-#warning The legacy version of click.dm is in use. This file is not updated with the main system, and is intended to be a fallback option in the event click code breaks. ^Spitzer
-#warning Travis failures will probably be caused by the warnings in this file.
+#warn The legacy version of click.dm is in use. This file is not updated with the main system, and is intended to be a fallback option in the event click code breaks. ^Spitzer
+#warn Travis failures will probably be caused by the warnings in this file.
 
 // 1 decisecond click delay (above and beyond mob/next_move)
 /mob/var/next_click = 0

--- a/code/_onclick/click_legacy.dm
+++ b/code/_onclick/click_legacy.dm
@@ -3,12 +3,8 @@
 	~Sayu
 */
 
-// // // ECLIPSE NOTE // // //
-/* This file is a partial revert of the Citadel patch. If any issues arise, use 
- * click_legacy.dm located in the same folder as a backup solution.
- *
- * Travis will not like it if you use the backup solution. Fair warning.
- */
+#warning The legacy version of click.dm is in use. This file is not updated with the main system, and is intended to be a fallback option in the event click code breaks. ^Spitzer
+#warning Travis failures will probably be caused by the warnings in this file.
 
 // 1 decisecond click delay (above and beyond mob/next_move)
 /mob/var/next_click = 0
@@ -45,7 +41,7 @@
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
 /mob/proc/ClickOn(var/atom/A, var/params)
-	if(world.time < next_click) // Hard check, before anything else, to avoid crashing
+	if(world.time <= next_click) // Hard check, before anything else, to avoid crashing
 		return
 
 	next_click = world.time + 1
@@ -113,7 +109,7 @@
 	//Atoms on your person
 	// A is your location but is not a turf; or is on you (backpack); or is on something on you (box in backpack); sdepth is needed here because contents depth does not equate inventory storage depth.
 	var/sdepth = A.storage_depth(src)
-	if((!isturf(A) && A == loc) || (sdepth != -1 && sdepth <= MAX_STORAGE_REACH))		//Eclipse edit - This line and the line similar to it about 20 lines down were the cause of the telekinesis bug on 2019-08-14. I've made tweaks to their fix, but I'm not going to fully apply their fix because of what exactly happened. ^Spitzer
+	if((!isturf(A) && A == loc) || (sdepth != -1 && sdepth <= 1))
 		if(W)
 			var/resolved = W.resolve_attackby(A, src)
 			if(!resolved && A && W)
@@ -132,7 +128,7 @@
 	//Atoms on turfs (not on your person)
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
-	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= MAX_STORAGE_REACH))		//Eclipse edit - see above.
+	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach)) ) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
@@ -181,7 +177,6 @@
 
 /mob/living/UnarmedAttack(var/atom/A, var/proximity_flag)
 
-	//Eclipse Note: Removed on Cit's server, but for now I'm re-adding it. ^Spitzer
 	if(!ticker)
 		src << "You cannot attack people before the game has started."
 		return 0


### PR DESCRIPTION
Partial revert of `click.dm` from the Cit merge. Players can no longer grab things through cameras. Or from across the room.

A backup file, `click_legacy.dm`, is included in the event that the fix breaks horribly; this is a full revert and contains everything exactly as it was before the upstream merge. Using it will issue warnings on the precompiler and cause Travis to shit its fuck; the former is intended and the latter is an unfortunate side effect of using the `#warn` precompiler command.