### PR TITLE
NT Department Alarm Dispatcher - Phase 1

### DIFF
--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -24,6 +24,12 @@
 	var/mice_wire_cooldown_rs = FALSE		//Roundstart mouse wire cooldown.
 	var/mice_wire_eng_req = FALSE			//Require engineers to chew wires?
 
+	//Dispatcher
+	var/enable_dispatcher = FALSE			//should it be enabled?
+	var/debug_dispatcher = 1				//debug the dispatcher
+	var/dispatch_bot_token = ""				//bot token for dispatcher
+	var/dispatcher_cooldown
+
 	//Miscellaneous
 	var/vote_extensions = 2
 	var/tip_of_the_round = FALSE			//Tip of the Round
@@ -87,6 +93,14 @@
 				config.mice_wire_cooldown_rs = TRUE
 			if("mice_require_engineers")
 				config.mice_wire_eng_req = TRUE
+			if("enable_dispatcher")
+				config.enable_dispatcher = TRUE
+			if("debug_dispatcher")
+				config.debug_dispatcher = text2num(value)
+			if("dispatch_bot_token")
+				config.dispatch_bot_token = value
+			if("dispatcher_cooldown")
+				config.dispatcher_cooldown = 10 * text2num(value)
 	
 	config.eclipse_config_loaded = TRUE
 	return 1

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -204,6 +204,35 @@ SUBSYSTEM_DEF(dispatch)
 // "This is a test of the Nanotrasen Department Alarm Dispatcher. This is only a test."
 	CRASH("Unimplemented.")
 
+/datum/controller/subsystem/dispatch/Shutdown()
+	//clear all lists
+	tracked_players_all = list()		//All tracked players
+	tracked_players_sec = list()		//Security
+	tracked_players_med = list()		//Medical
+	tracked_players_sci = list()		//Science
+	tracked_players_cmd = list()		//Command
+	tracked_players_crg = list()		//Supply
+	tracked_players_eng = list()		//Engineering
+	tracked_players_svc = list()		//Service
+
+	//I'm sure Nestor will want to do something here with the Discord bot he has planned, later
+	
+/datum/controller/subsystem/dispatch/stat_entry(msg_prefix)
+	var/list/msg = list(msg_prefix)
+	msg += "T:[tracked_players_all.len]"		//Total
+	msg += "{"
+	msg += "H [tracked_players_cmd.len] | "		//Heads
+	msg += "E [tracked_players_eng.len] | "		//Engi
+	msg += "S [tracked_players_sec.len] | "		//Sec
+	msg += "M [tracked_players_med.len] | "		//Med
+	msg += "R [tracked_players_sci.len] | "		//Research
+	msg += "C [tracked_players_crg.len] | "		//Cargo
+	msg += "O [tracked_players_svc.len]"		//Other
+	msg += "}"
+	..(msg.Join())
+	
+	//sample T:28{H 6|E 3|S 4|M 4|R 5|C 5|O 12}
+
 #undef DEBUGLEVEL_FATAL_ONLY
 #undef DEBUGLEVEL_SEVERE
 #undef DEBUGLEVEL_WARNING

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -1,3 +1,4 @@
+var/global/datum/controller/dispatcher/dispatcher		//how bothersome.
 /* 
  * Nanotrasen Department Alarm Dispatcher
  * This handles out-of-server calls for players, using the request console. We
@@ -10,8 +11,7 @@
 #define DEBUGLEVEL_VERBOSE 3
 
 
-SUBSYSTEM_DEF(dispatcher)
-	// Metadata; you should define these.
+SUBSYSTEM_DEF(dispatcher)		
 	name = "Dispatcher" //name of the subsystem
 	init_order = -2		//lower priority, really
 	flags = SS_BACKGROUND		//run in background. We only really need this for global stuff.

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -113,7 +113,7 @@ SUBSYSTEM_DEF(dispatcher)
 		log_debug("DISPATCHER: Added [M] to tracked players.")
 	return 1
 
-/datum/controller/subsystem/dispatcher/proc/removeFromTracking(mob/living/M)
+/datum/controller/subsystem/dispatcher/proc/removeFromTracking(mob/M)		//we don't need the precision here, since we may be removing dead players
 	if(!M)
 		CRASH("no mob specified.")
 	if(!M.mind)

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -113,7 +113,6 @@ SUBSYSTEM_DEF(dispatch)
 		log_debug("DISPATCHER: Added [M] to tracked players.")
 	return 1
 
-/* on hold until I can get a copy of the DM reference to check if a list contains an entry
 /datum/controller/subsystem/dispatch/proc/removeFromTracking(mob/living/M)
 	if(!M)
 		CRASH("no mob specified.")
@@ -122,29 +121,48 @@ SUBSYSTEM_DEF(dispatch)
 	if(!M.mind.assigned_role)
 		return 0	//No assigned role.
 
-
+	//...departments first...
 	if(tracked_players_sec & M)
 		tracked_players_sec -= M
-	if(M.mind.assigned_role in medical_positions)
+	if(tracked_players_med & M)
 		tracked_players_med -= M
-	if(M.mind.assigned_role in science_positions)
+	if(tracked_players_sci & M)
 		tracked_players_sci -= M
-	if(M.mind.assigned_role in command_positions)
-		if(M.mind.assigned_role != "Command Secretary")		//We don't count the secretary.
-			tracked_players_cmd -= M
-	if(M.mind.assigned_role in cargo_positions)
+	if(tracked_players_cmd & M)
+		tracked_players_cmd -= M
+	if(tracked_players_crg & M)
 		tracked_players_crg -= M
-	if(M.mind.assigned_role in engineering_positions)
+	if(tracked_players_eng & M)
 		tracked_players_eng -= M
-	if(M.mind.assigned_role in civilian_positions)
-		if(M.mind.assigned_role != (USELESS_JOB || "Intern"))		//visitors are not staff, and interns have no access.
-			tracked_players_svc -= M
+	if(tracked_players_svc & M)
+		tracked_players_svc -= M
+	
+	//...then the final list.
+	if(tracked_players_all & M)
+		tracked_players_all -= M
 
 	if(DEBUGLEVEL_VERBOSE <= debug_level)
-		log_debug("DISPATCHER: Added [M] to tracked players.")
+		log_debug("DISPATCHER: Removed [M] from tracked players.")
 	return 1
 
-*/
+/datum/controller/subsystem/dispatch/proc/handleRequest(department = "", priority = FALSE, message)
+//return statement should be whether or not the handler handled it.
+//0 if it is kicking it back to the RC due to players being on,
+//1 if it sent to Discord.
+	department = lowertext(department)
+	switch(department)
+		if("engineering")
+			if(!tracked_players_eng)
+				sendDiscordRequest("engineering",priority, message)
+				return 1
+			else
+				return 0
+		else
+			Error("Unimplemented department \"[department]\".")
+
+/datum/controller/subsystem/dispatch/proc/sendDiscordRequest(department = "", priority = FALSE, message)
+// "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping] from [sender] ([sender_role]): '[message]'"
+	CRASH("Unimplemented.")
 
 #undef DEBUGLEVEL_FATAL_ONLY
 #undef DEBUGLEVEL_SEVERE

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -65,7 +65,7 @@ SUBSYSTEM_DEF(dispatch)
 		if(!M.mind.assigned_role)
 			continue	//No assigned role.
 		
-	tracked_players_all += M
+		tracked_players_all += M
 		if(DEBUGLEVEL_VERBOSE <= debug_level)
 			log_debug("DISPATCHER: Master list population: [tracked_players_all.len] players.")
 		

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -13,9 +13,9 @@
 SUBSYSTEM_DEF(dispatch)
 	// Metadata; you should define these.
 	name = "Dispatch" //name of the subsystem
-	var/init_order = -2		//lower priority, really
-	var/flags = SS_BACKGROUND		//run in background. We only really need this for global stuff.
-	var/runlevels = RUNLEVELS_DEFAULT
+	init_order = -2		//lower priority, really
+	flags = SS_BACKGROUND		//run in background. We only really need this for global stuff.
+	runlevels = RUNLEVELS_DEFAULT
 	var/static/dispatcher_initialized = FALSE		//American spelling, for consistency.
 	var/debug_level = DEBUGLEVEL_FATAL_ONLY
 	
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(dispatch)
 	
 	//make sure they're clear
 	if(tracked_players_all || tracked_players_sec || tracked_players_med || tracked_players_sci || tracked_players_cmd || tracked_players_crg || tracked_players_eng || tracked_players_svc)
-		Error("DISPATCHER: Attempted to flush player lists, but lists still had data. Abnormalities may occur!")
+		world.Error("DISPATCHER: Attempted to flush player lists, but lists still had data. Abnormalities may occur!")
 		if(DEBUGLEVEL_SEVERE <= debug_level)		//Yoda programming here.
 			log_debug("DISPATCHER: Attempted to flush player lists, but lists still had data.")
 	else if(DEBUGLEVEL_VERBOSE <= debug_level)		//Yoda programming here.
@@ -158,7 +158,7 @@ SUBSYSTEM_DEF(dispatch)
 			else
 				return 0
 		else
-			Error("Unimplemented department \"[department]\".")
+			world.Error("Unimplemented department \"[department]\".")
 
 /datum/controller/subsystem/dispatch/proc/sendDiscordRequest(department = "", priority = FALSE, message)
 // "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping] from [sender] ([sender_role]): '[message]'"

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -29,11 +29,11 @@ SUBSYSTEM_DEF(dispatcher)
 	var/list/tracked_players_eng = list()		//Engineering
 	var/list/tracked_players_svc = list()		//Service
 	
-/datum/controller/subsystem/dispatch/Recover()
+/datum/controller/subsystem/dispatcher/Recover()
 	flags |= SS_NO_INIT // We don't want to init twice.
 	flushTracking()
 
-/datum/controller/subsystem/dispatch/proc/flushTracking()
+/datum/controller/subsystem/dispatcher/proc/flushTracking()
 	//First, we reset all the lists.
 	if(DEBUGLEVEL_VERBOSE <= debug_level)		//Yoda programming here.
 		log_debug("DISPATCHER: Flushing lists.")
@@ -83,7 +83,7 @@ SUBSYSTEM_DEF(dispatcher)
 			addToTracking(M)
 			continue		//We're done adding here.
 
-/datum/controller/subsystem/dispatch/proc/addToTracking(mob/living/M)
+/datum/controller/subsystem/dispatcher/proc/addToTracking(mob/living/M)
 	if(!M)
 		CRASH("no mob specified.")
 	if(!M.mind)
@@ -113,7 +113,7 @@ SUBSYSTEM_DEF(dispatcher)
 		log_debug("DISPATCHER: Added [M] to tracked players.")
 	return 1
 
-/datum/controller/subsystem/dispatch/proc/removeFromTracking(mob/living/M)
+/datum/controller/subsystem/dispatcher/proc/removeFromTracking(mob/living/M)
 	if(!M)
 		CRASH("no mob specified.")
 	if(!M.mind)
@@ -145,7 +145,7 @@ SUBSYSTEM_DEF(dispatcher)
 		log_debug("DISPATCHER: Removed [M] from tracked players.")
 	return 1
 
-/datum/controller/subsystem/dispatch/proc/handleRequest(department = "", priority = FALSE, message, sender = "Unknown", sender_role = "Unassigned")
+/datum/controller/subsystem/dispatcher/proc/handleRequest(department = "", priority = FALSE, message, sender = "Unknown", sender_role = "Unassigned")
 //return statement should be whether or not the handler handled it.
 //0 if it is kicking it back to the RC due to players being on,
 //1 if it sent to Discord.
@@ -196,15 +196,15 @@ SUBSYSTEM_DEF(dispatcher)
 		else
 			world.Error("Unimplemented department \"[department]\".")
 
-/datum/controller/subsystem/dispatch/proc/sendDiscordRequest(department = "", priority = FALSE, message, sender, sender_role)
+/datum/controller/subsystem/dispatcher/proc/sendDiscordRequest(department = "", priority = FALSE, message, sender, sender_role)
 // "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping] from [sender] ([sender_role]): '[message]'"
 	CRASH("Unimplemented. Department [department], priority [priority], message [message], sender [sender], sender role [sender_role].")
 	
-/datum/controller/subsystem/dispatch/proc/sendDiscordTest()
+/datum/controller/subsystem/dispatcher/proc/sendDiscordTest()
 // "This is a test of the Nanotrasen Department Alarm Dispatcher. This is only a test."
 	CRASH("Unimplemented.")
 
-/datum/controller/subsystem/dispatch/Shutdown()
+/datum/controller/subsystem/dispatcher/Shutdown()
 	//clear all lists
 	tracked_players_all = list()		//All tracked players
 	tracked_players_sec = list()		//Security
@@ -217,7 +217,7 @@ SUBSYSTEM_DEF(dispatcher)
 
 	//I'm sure Nestor will want to do something here with the Discord bot he has planned, later
 	
-/datum/controller/subsystem/dispatch/stat_entry(msg_prefix)
+/datum/controller/subsystem/dispatcher/stat_entry(msg_prefix)
 	var/list/msg = list(msg_prefix)
 	msg += "T:[tracked_players_all.len]"		//Total
 	msg += "{"

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -145,7 +145,7 @@ SUBSYSTEM_DEF(dispatch)
 		log_debug("DISPATCHER: Removed [M] from tracked players.")
 	return 1
 
-/datum/controller/subsystem/dispatch/proc/handleRequest(department = "", priority = FALSE, message)
+/datum/controller/subsystem/dispatch/proc/handleRequest(department = "", priority = FALSE, message, sender = "Unknown", sender_role = "Unassigned")
 //return statement should be whether or not the handler handled it.
 //0 if it is kicking it back to the RC due to players being on,
 //1 if it sent to Discord.
@@ -153,15 +153,55 @@ SUBSYSTEM_DEF(dispatch)
 	switch(department)
 		if("engineering")
 			if(!tracked_players_eng)
-				sendDiscordRequest("engineering",priority, message)
+				sendDiscordRequest("engineering",priority, message, sender, sender_role)
+				return 1
+			else
+				return 0
+		if("science")
+			if(!tracked_players_sci)
+				sendDiscordRequest("research",priority, message, sender, sender_role)
+				return 1
+			else
+				return 0
+		if("security")
+			if(!tracked_players_sec)
+				sendDiscordRequest("security",priority, message, sender, sender_role)
+				return 1
+			else
+				return 0
+		if("supply")
+			if(!tracked_players_crg)
+				sendDiscordRequest("supply",priority, message, sender, sender_role)
+				return 1
+			else
+				return 0
+		if("service")
+			if(!tracked_players_svc)
+				sendDiscordRequest("service",priority, message, sender, sender_role)
+				return 1
+			else
+				return 0
+		if("medical")
+			if(!tracked_players_med)
+				sendDiscordRequest("medical",priority, message, sender, sender_role)
+				return 1
+			else
+				return 0
+		if("command")
+			if(!tracked_players_cmd)
+				sendDiscordRequest("command",priority, message, sender, sender_role)
 				return 1
 			else
 				return 0
 		else
 			world.Error("Unimplemented department \"[department]\".")
 
-/datum/controller/subsystem/dispatch/proc/sendDiscordRequest(department = "", priority = FALSE, message)
+/datum/controller/subsystem/dispatch/proc/sendDiscordRequest(department = "", priority = FALSE, message, sender, sender_role)
 // "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping] from [sender] ([sender_role]): '[message]'"
+	CRASH("Unimplemented. Department [department], priority [priority], message [message], sender [sender], sender role [sender_role].")
+	
+/datum/controller/subsystem/dispatch/proc/sendDiscordTest()
+// "This is a test of the Nanotrasen Department Alarm Dispatcher. This is only a test."
 	CRASH("Unimplemented.")
 
 #undef DEBUGLEVEL_FATAL_ONLY

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -1,4 +1,5 @@
-var/global/datum/controller/dispatcher/dispatcher		//how bothersome.
+var/global/datum/controller/subsystem/dispatcher/dispatcher		//This must be defined here, else dispatcher.Proc() calls will fail
+
 /* 
  * Nanotrasen Department Alarm Dispatcher
  * This handles out-of-server calls for players, using the request console. We
@@ -28,7 +29,7 @@ SUBSYSTEM_DEF(dispatcher)
 	var/list/tracked_players_crg = list()		//Supply
 	var/list/tracked_players_eng = list()		//Engineering
 	var/list/tracked_players_svc = list()		//Service
-	
+
 /datum/controller/subsystem/dispatcher/Recover()
 	flags |= SS_NO_INIT // We don't want to init twice.
 	flushTracking()

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -1,0 +1,10 @@
+/datum/controller/subsystem
+	// Metadata; you should define these.
+	name = "Dispatch" //name of the subsystem
+	var/init_order = INIT_ORDER_DEFAULT	//order of initialization. Higher numbers are initialized first, lower numbers later. Can be decimal and negative values.
+	var/flags = SS_BACKGROUND
+	var/runlevels = RUNLEVELS_DEFAULT
+
+	//set to 0 to prevent fire() calls, mostly for admin use or subsystems that may be resumed later
+	//	use the SS_NO_FIRE flag instead for systems that never fire to keep it from even being added to the list
+	var/can_fire = TRUE

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -1,10 +1,24 @@
-/datum/controller/subsystem
+/* 
+ * Nanotrasen Department Alarm Dispatcher
+ * This handles out-of-server calls for players, using the request console. We
+ * have this set up as a subsystem so we can handle it with global lists.
+ */
+
+SUBSYSTEM_DEF(dispatch)
 	// Metadata; you should define these.
 	name = "Dispatch" //name of the subsystem
-	var/init_order = INIT_ORDER_DEFAULT	//order of initialization. Higher numbers are initialized first, lower numbers later. Can be decimal and negative values.
-	var/flags = SS_BACKGROUND
+	var/init_order = -2		//lower priority, really
+	var/flags = SS_BACKGROUND		//run in background. We only really need this for global stuff.
 	var/runlevels = RUNLEVELS_DEFAULT
-
-	//set to 0 to prevent fire() calls, mostly for admin use or subsystems that may be resumed later
-	//	use the SS_NO_FIRE flag instead for systems that never fire to keep it from even being added to the list
-	var/can_fire = TRUE
+	var/static/dispatcher_initialized = FALSE		//American spelling, for consistency.
+	
+	//used in player tracking system
+	var/list/tracked_players_all = list()		//All tracked players
+	var/list/tracked_players_sec = list()		//Security
+	var/list/tracked_players_med = list()		//Medical
+	var/list/tracked_players_sci = list()		//Science
+	var/list/tracked_players_cmd = list()		//Command
+	var/list/tracked_players_crg = list()		//Supply
+	var/list/tracked_players_eng = list()		//Engineering
+	var/list/tracked_players_svc = list()		//Service
+	

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -324,7 +324,7 @@ SUBSYSTEM_DEF(dispatcher)
 		
 	var/msg = ""		//This is the string intended to be sent to the bot.
 	if(stamped)
-		msg = "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping],stamped by [stamped][sender ? ", from [sender] ([sender_role])" : "" ]: '[message]'"
+		msg = "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping], stamped by [stamped][sender ? ", from [sender] ([sender_role])" : "" ]: '[message]'"
 	else
 		msg = "[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping], from [sender] ([sender_role]): '[message]'"
 	

--- a/code/controllers/subsystems/dispatcher_eclipse.dm
+++ b/code/controllers/subsystems/dispatcher_eclipse.dm
@@ -10,9 +10,9 @@
 #define DEBUGLEVEL_VERBOSE 3
 
 
-SUBSYSTEM_DEF(dispatch)
+SUBSYSTEM_DEF(dispatcher)
 	// Metadata; you should define these.
-	name = "Dispatch" //name of the subsystem
+	name = "Dispatcher" //name of the subsystem
 	init_order = -2		//lower priority, really
 	flags = SS_BACKGROUND		//run in background. We only really need this for global stuff.
 	runlevels = RUNLEVELS_DEFAULT

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -80,7 +80,6 @@ var/global/datum/controller/occupations/job_master
 				player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 				unassigned -= player
 				job.current_positions++
-				dispatcher.addToTracking(player)		//Eclipse edit - NT DAD
 				return 1
 		Debug("AR has failed, Player: [player], Rank: [rank]")
 		return 0
@@ -546,6 +545,9 @@ var/global/datum/controller/occupations/job_master
 		BITSET(H.hud_updateflag, ID_HUD)
 		BITSET(H.hud_updateflag, IMPLOYAL_HUD)
 		BITSET(H.hud_updateflag, SPECIALROLE_HUD)
+		
+		//lastly, add them to the player tracking system
+		dispatcher.addToTracking(H)		//Eclipse edit
 		return H
 
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -164,7 +164,7 @@ var/global/datum/controller/occupations/job_master
 			if((player) && (player.mind))
 				player.mind.assigned_role = null
 				player.mind.special_role = null
-				dispatcher.removeFromTracking(player)		//Eclipse edit: NT DAD
+				dispatcher.removeFromTracking(player)
 		SetupOccupations()
 		unassigned = list()
 		return

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -80,6 +80,7 @@ var/global/datum/controller/occupations/job_master
 				player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 				unassigned -= player
 				job.current_positions++
+				dispatcher.addToTracking(player)		//Eclipse edit - NT DAD
 				return 1
 		Debug("AR has failed, Player: [player], Rank: [rank]")
 		return 0
@@ -163,6 +164,7 @@ var/global/datum/controller/occupations/job_master
 			if((player) && (player.mind))
 				player.mind.assigned_role = null
 				player.mind.special_role = null
+				dispatcher.removeFromTracking(player)		//Eclipse edit: NT DAD
 		SetupOccupations()
 		unassigned = list()
 		return

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -164,7 +164,7 @@ var/global/datum/controller/occupations/job_master
 			if((player) && (player.mind))
 				player.mind.assigned_role = null
 				player.mind.special_role = null
-				dispatcher.removeFromTracking(player)
+		dispatcher.flushTracking()		//Eclipse edit: NT DAD
 		SetupOccupations()
 		unassigned = list()
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -381,7 +381,6 @@
 /obj/machinery/cryopod/proc/despawn_occupant(var/mob/to_despawn)
 	//Recursively despawn mobs
 	for(var/mob/M in to_despawn)
-		dispatcher.removeFromTracking(M)		//Eclipse edit - NT DAD
 		despawn_occupant(M)
 
 	// VOREStation
@@ -514,6 +513,8 @@
 	//visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [to_despawn.real_name] into storage.</span>", 3)
 	visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2].</span>", 3)
 
+	//Remove from dispatcher.
+	dispatcher.removeFromTracking(to_despawn)		//Eclipse edit - NT DAD
 
 	//This should guarantee that ghosts don't spawn.
 	to_despawn.ckey = null

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -513,6 +513,9 @@
 	//visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [to_despawn.real_name] into storage.</span>", 3)
 	visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2].</span>", 3)
 
+	//Remove from dispatcher.
+	dispatcher.removeFromTracking(to_despawn)		//Eclipse edit - NT DAD
+
 	//This should guarantee that ghosts don't spawn.
 	to_despawn.ckey = null
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -381,6 +381,7 @@
 /obj/machinery/cryopod/proc/despawn_occupant(var/mob/to_despawn)
 	//Recursively despawn mobs
 	for(var/mob/M in to_despawn)
+		dispatcher.removeFromTracking(M)		//Eclipse edit - NT DAD
 		despawn_occupant(M)
 
 	// VOREStation
@@ -513,8 +514,6 @@
 	//visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [to_despawn.real_name] into storage.</span>", 3)
 	visible_message("<span class='notice'>\The [initial(name)] [on_store_visible_message_1] [to_despawn.real_name] [on_store_visible_message_2].</span>", 3)
 
-	//Remove from dispatcher.
-	dispatcher.removeFromTracking(to_despawn)		//Eclipse edit - NT DAD
 
 	//This should guarantee that ghosts don't spawn.
 	to_despawn.ckey = null

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -55,6 +55,11 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	var/priority = -1 ; //Priority of the message being sent
 	light_range = 0
 	var/datum/announcement/announcement = new
+	
+	// // // ECLIPSE ADDED VARS // // //
+	var/verifyName = ""
+	var/verifyRank = ""
+	var/stampName = ""
 
 /obj/machinery/requests_console/power_change()
 	..()
@@ -170,7 +175,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		screen = RCS_SENTFAIL
 		for (var/obj/machinery/message_server/MS in machines)
 			if(!MS.active) continue
-			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority)
+			MS.send_rc_message(ckey(href_list["department"]),department,log_msg,msgStamped,msgVerified,priority,verifyName,verifyRank,stampName)		//Eclipse Edit: NT DAD
 			pass = 1
 		if(pass)
 			screen = RCS_SENTPASS
@@ -236,7 +241,11 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	if(istype(O, /obj/item/weapon/card/id))
 		if(inoperable(MAINT)) return
 		if(screen == RCS_MESSAUTH)
+			// // // BEGIN ECLIPSE EDITS // // //
+			// NT Department Alarm Dispatcher
 			var/obj/item/weapon/card/id/T = O
+			verifyName = T.registered_name
+			verifyRank = T.assignment
 			msgVerified = text("<font color='green'><b>Verified by [T.registered_name] ([T.assignment])</b></font>")
 			updateUsrDialog()
 		if(screen == RCS_ANNOUNCE)
@@ -252,6 +261,8 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		if(inoperable(MAINT)) return
 		if(screen == RCS_MESSAUTH)
 			var/obj/item/weapon/stamp/T = O
+			stampName = T.name
+			// // // END ECLIPSE EDITS // // //
 			msgStamped = text("<font color='blue'><b>Stamped with the [T.name]</b></font>")
 			updateUsrDialog()
 	return
@@ -261,7 +272,10 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 	recipient = ""
 	priority = 0
 	msgVerified = ""
+	verifyName = ""		//Eclipse add
+	verifyRank = ""		//Eclipse add
 	msgStamped = ""
+	stampName = ""		//Eclipse add
 	announceAuth = 0
 	announcement.announcer = ""
 	if(mainmenu)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1016,6 +1016,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		var/obj/machinery/cryopod/CP = human_cryopods[input(usr,"Select a cryopod to use","Cryopod Choice") as null|anything in human_cryopods]
 		if(!CP)
 			return
+		dispatcher.removeFromTracking(M)		//Eclipse edit: NT DAD
 		M.ghostize()
 		CP.despawn_occupant(M)
 		return
@@ -1036,5 +1037,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			return
 
 	else if(isliving(M))
+		dispatcher.removeFromTracking(M)		//Eclipse edit: NT DAD
 		M.ghostize()
 		qdel(M) //Bye

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -452,6 +452,20 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		else
 			equipment = 0
 
+	// // // BEGIN ECLIPSE EDIT // // //
+	//If they have a job, let's offer to add them to the player tracking system.
+	//There may be a reason for them to not be, so let's leave it to the admin's
+	//discretion whether or not to.
+	
+	var/ptrack
+	if(charjob)
+		ptrack = alert(src,"Add them to the player tracking subsystem? This may affect whether the NT Department Alarm Dispatcher will ping on Discord for someone for their role, if they're the only person in their department.", "Player Tracking", "Yes", "No")
+		if(ptrack == "Yes")
+			ptrack = 1
+		else
+			ptrack = 0
+	// // // END ECLIPSE EDIT (for now) // // //
+
 	//For logging later
 	var/admin = key_name_admin(src)
 	var/player_key = picked_client.key
@@ -516,6 +530,13 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(charjob)
 			job_master.EquipRank(new_character, charjob, 1)
 		equip_custom_items(new_character)
+
+	// // // BEGIN ECLIPSE EDIT // // //
+	//If desired, add them to the PTrack system
+	if(ptrack)
+		dispatcher.addToTracking(new_character)
+	// // // END ECLIPSE EDIT // // //
+
 
 	//If desired, add records.
 	if(records)

--- a/code/modules/mob/dead/observer/free_vr.dm
+++ b/code/modules/mob/dead/observer/free_vr.dm
@@ -42,7 +42,7 @@ var/global/list/prevent_respawns = list()
 	//Job slot cleanup
 	var/job = src.mind.assigned_role
 	job_master.FreeRole(job)
-	dispatcher.removeFromTracking(src)
+	dispatcher.removeFromTracking(src)	//Eclipse Edit - NT DAD
 
 	//Their objectives cleanup
 	if(src.mind.objectives.len)

--- a/code/modules/mob/dead/observer/free_vr.dm
+++ b/code/modules/mob/dead/observer/free_vr.dm
@@ -42,6 +42,7 @@ var/global/list/prevent_respawns = list()
 	//Job slot cleanup
 	var/job = src.mind.assigned_role
 	job_master.FreeRole(job)
+	dispatcher.removeFromTracking(src)
 
 	//Their objectives cleanup
 	if(src.mind.objectives.len)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -106,13 +106,16 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	pda_msgs += new/datum/data_pda_msg(recipient,sender,message)
 	return result
 
-/obj/machinery/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1)
+/obj/machinery/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1, var/id_name = "", var/id_rank = "", var/stamp_name = "")		//Eclipse Edit: Added ID name, rank, and stamp name for discord passthrough
 	rc_msgs += new/datum/data_rc_msg(recipient,sender,message,stamp,id_auth)
 	var/authmsg = "[message]<br>"
 	if (id_auth)
 		authmsg += "[id_auth]<br>"
 	if (stamp)
 		authmsg += "[stamp]<br>"
+	
+	dispatcher.handleRequest(recipient, priority, message, id_name, id_rank, stamp_name)		//Eclipse Add: Department alarm dispatcher.
+	
 	for (var/obj/machinery/requests_console/Console in allConsoles)
 		if (ckey(Console.department) == ckey(recipient))
 			if(Console.inoperable())

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -114,7 +114,15 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 	if (stamp)
 		authmsg += "[stamp]<br>"
 	
-	dispatcher.handleRequest(recipient, priority, message, id_name, id_rank, stamp_name)		//Eclipse Add: Department alarm dispatcher.
+	// // // BEGIN ECLIPSE EDIT // // //
+	// Department alarm dispatcher
+	if(world.time >= dispatcher.cooldown)	// if we're not in cooldown, pass it along
+		dispatcher.handleRequest(recipient, priority, message, id_name, id_rank, stamp_name)
+	else		//if we are, log it to debug
+		var/cooldown_left = (dispatcher.cooldown - world.time) / 10
+		if(dispatcher.debug_level > 2)		//if debugging is on
+			log_debug("DISPATCHER/message_server.dm: Messaging server still in dispatch cooldown for [cooldown_left] seconds.")
+	// // // END ECLIPSE EDIT // // //
 	
 	for (var/obj/machinery/requests_console/Console in allConsoles)
 		if (ckey(Console.department) == ckey(recipient))

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -87,6 +87,39 @@ ROUNDSTART_MOUSE_WIRE_COOLDOWN
 MICE_REQUIRE_ENGINEERS
 
 #########
+# DISPATCHER
+#########
+
+## MASTER ENABLE
+## Should the dispatcher be enabled? If disabled, only the player tracking system
+## will be functional.
+## Uncomment to enable.
+# ENABLE_DISPATCHER
+
+## DEBUG LEVEL
+## What level should we debug the dispatcher on?
+## 0 - Fatal and runtimes only
+## 1 - Severe
+## 2 - Warnings
+## 3 - Verbose
+# Default is 1.
+DEBUG_DISPATCHER 1
+
+## DISPATCHER BOT TOKEN
+## For anonymity, it is recommended that the discord bot token is set here rather
+## than hardcoded. Parses as a string.
+## Default is unset.
+## Example: DISPATCH_BOT_TOKEN 1a2b3c
+DISPATCH_BOT_TOKEN
+
+## DISPATCHER COOLDOWN
+## After a message is sent, how long should the global cooldown be before another
+## can be sent to the dispatcher? 
+## Default is 180 seconds (3 minutes)
+## Units: Seconds
+DISPATCHER_COOLDOWN 180
+
+#########
 # MISCELLANY
 #########
 

--- a/eclipsestation.dme
+++ b/eclipsestation.dme
@@ -238,6 +238,7 @@
 #include "code\controllers\subsystems\atoms.dm"
 #include "code\controllers\subsystems\bellies_vr.dm"
 #include "code\controllers\subsystems\circuits.dm"
+#include "code\controllers\subsystems\dispatcher_eclipse.dm"
 #include "code\controllers\subsystems\garbage.dm"
 #include "code\controllers\subsystems\holomaps.dm"
 #include "code\controllers\subsystems\lighting.dm"


### PR DESCRIPTION
Going to go ahead and draft up a PR, so I can get everything ready and started for the NT DAD and stop cluttering up that one card. This is the plans and all that.

**This is part 1 of that.**

## Overview
Adds framework for the NT Department Alarm Dispatcher. This framework will tie in to the current Request Console System's "request assistance" feature. This is intended to 

### Intended functionality
If a player requests assistance from a department AND the department does not have any players, the NT DAD should go to the Discord's role pings channel and ping the relevant group. If the player requests a department head, the NT DAD should act as if the department itself was pinged.

If the department requested has players, the request consoles should receive the message as normal, without a NT DAD ping.

I'll need to tie into the player join and player leave code, otherwise I'll have to flush the list every time a request console blip goes through. This means the DAD will probably end up being its own subsystem. To do this, I'll probably end up creating a master list of everyone tracked by the DAD, then create sub-lists for each department containing everyone in those departments. 

I plan to create an 'add' proc to add players to NTDAD's tracking, a 'remove' proc to remove players from NTDAD's tracking, and a 'flush' proc to remove everyone from NTDAD's tracking and re-add everyone from square one (debugging use, mostly).

### Intended messages

```DM
"[priority ? "**HIGH PRIORITY** a" : "A"]ssistance request for [department_ping] from [sender] ([sender_role]): '[message]'"
```

* **HIGH PRIORITY** assistance request for Engineering from John Doe (Visitor): 'the power is fucked'
* Assistance request for Medical from John Doe (visitor): 'the guy setting power up is fucked'

### Foreseen Issues
* If a player needs a department for that same department (e.g. a medic to revive a medic, or security because all of security is dead), the NT DAD won't ping. I'll need to figure out what to do in that scenario.
* I have *never created a subsystem before.*
* Flushing the NTDAD's lists is probably going to add a bit of latency as many variables are being changed all at once.
* If a player add/remove command is missed, the DAD will not function properly. This can be alleviated by running a flush every X seconds, but I really don't want to do that (see above bullet).