### PR TITLE
Fixes regional ATC

### DIFF
--- a/code/modules/busy_space/air_traffic.dm
+++ b/code/modules/busy_space/air_traffic.dm
@@ -30,7 +30,7 @@ var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 
 /datum/lore/atc_controller/proc/msg(var/message,var/sender)
 	ASSERT(message)
-	global_announcer.autosay("[message]", sender ? sender : "[using_map.station_short] Space Control", "ATC")		//Eclipse Edit: ATC chatter has its own channel now
+	global_announcer.autosay("[message]", sender ? sender : "[using_map.station_short] Space Control", "ATC (Regional)")		//Eclipse Edit: ATC chatter has its own channel now
 
 /datum/lore/atc_controller/proc/reroute_traffic(var/yes = 1)
 	if(yes)


### PR DESCRIPTION
For some reason, the change where I made this its own channel didn't commit. Which is weird, because I could have sworn that it worked in testing.

:cl: EvilJackCarver
🔧 Fixes regional ATC chatter.
/:cl:

# UNTESTED