### PR TITLE
Assorted fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 # to the same file or dir, add them to the end under Multiple Owners
 
 # DrExample / Nestor
+###############
 
 /.github/ @DrExample
 /SQL/ @DrExample
@@ -28,6 +29,7 @@
 
 
 # EvilJackCarver / Gaz
+###############
 
 /code/ZAS/ @EvilJackCarver
 /code/controllers/configuration_eclipse.dm @EvilJackCarver
@@ -48,4 +50,9 @@
 
 
 # Multiple Owners
-/maps/southern_cross/ @DrExample @EvilJackCarver
+###############
+
+# Mapping related
+
+maps/southern_cross/ @DrExample @EvilJackCarver
+*.dmm @DrExample @EvilJackCarver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,10 +30,10 @@
 # EvilJackCarver / Gaz
 
 /code/ZAS/ @EvilJackCarver
-/code/controllers/configuration_eclipse.dm
-/code/controllers/emergency_shuttle_controller.dm
-/code/controllers/failsafe.dm
-/code/controllers/master.dm
+/code/controllers/configuration_eclipse.dm @EvilJackCarver
+/code/controllers/emergency_shuttle_controller.dm @EvilJackCarver
+/code/controllers/failsafe.dm @EvilJackCarver
+/code/controllers/master.dm @EvilJackCarver
 /code/modules/power/ @EvilJackCarver
 /modular_citadel/code/modules/projectiles/ @EvilJackCarver
 /modular_eclipse/code/modules/projectiles/ @EvilJackCarver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,4 +55,6 @@
 # Mapping related
 
 maps/southern_cross/ @DrExample @EvilJackCarver
+maps/submaps/ @DrExample @EvilJackCarver
+maps/RandomZLevels/ @DrExample @EvilJackCarver
 *.dmm @DrExample @EvilJackCarver

--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -54,7 +54,9 @@ var/datum/controller/supply/supply_controller = new()
 
 	for(var/typepath in subtypesof(/datum/supply_pack))
 		var/datum/supply_pack/P = new typepath()
-		supply_pack[P.name] = P
+		if(!isnull(P) && !isnull(P.name))		//Eclipse edit: if reference is not null and name is not null, go ahead
+			if(P.cost)							//Eclipse edit: No freebies!
+				supply_pack[P.name] = P
 
 /datum/controller/process/supply/setup()
 	name = "supply controller"

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -5,8 +5,8 @@
 	item_state = "signaler"
 	var/code = "electronic"
 	origin_tech = list(TECH_BLUESPACE = 1)
-	description_info = ""
-	icon = 'icons/obj/radio_vr.dmi'
+	description_info = ""		//Eclipse edit: Icon fixes from radio sprite update
+	icon = 'icons/obj/radio_vr.dmi'			//Eclipse edit: Icon fixes from radio sprite update
 
 GLOBAL_LIST_BOILERPLATE(all_beacons, /obj/item/device/radio/beacon)
 

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -5,6 +5,8 @@
 	item_state = "signaler"
 	var/code = "electronic"
 	origin_tech = list(TECH_BLUESPACE = 1)
+	description_info = ""
+	icon = 'icons/obj/radio_vr.dmi'
 
 GLOBAL_LIST_BOILERPLATE(all_beacons, /obj/item/device/radio/beacon)
 

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -210,19 +210,24 @@ var/list/global/map_templates = list()
 			
 			// // // BEGIN ECLIPSE EDIT // // //
 			//Speed up the submap generation system, by giving up if we start running low on sanity.
-			switch(overall_sanity)			//can probably put this to an equation, but also can't really be arsed.
-				if(0 to 15)
-					if(budget < 25)
-						admin_notice("Submap loader giving up at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
-						break
-				if(16 to 30)
-					if(budget < 15)
-						admin_notice("Submap loader giving up at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
-						break
-				if(31 to 45)
-					if(budget < 5)
-						admin_notice("Submap loader giving up at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
-						break
+/*
+ * SUBMAP GENERATOR YIELDING
+ * The submap loader will yield if the budget is below a certain value, based on
+ * the current sanity. This graphs as y <= -4/9x + 25, where Y is budget and X
+ * is sanity. Yielding begins at 56.25 sanity if budget below 0, and ends at 
+ * 0 sanity if budget is below 25 (if it hits zero it'll abort anyway).
+ */
+			if(budget <= ((-(4/9) * overall_sanity) + 25))
+				admin_notice("Submap loader yielding at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
+				break
+				
+/*
+ * MORE QUICK NUMBERS:
+ * If sanity is 5, will yield if budget below 22.777...(REPEATED)
+ * If sanity is 10, will yield if budget below 20.555...(REPEATED)
+ * If sanity is 25, will yield if budget below 13.888...(REPEATED)
+ * If sanity is 50, will yield if budget below 2.777...(REPEATED)
+ */
 			// // // END ECLIPSE EDIT // // //
 
 		else // We're out of submaps.

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -207,6 +207,23 @@ var/list/global/map_templates = list()
 				chosen_template = pick(priority_submaps)
 			else
 				chosen_template = pick(potential_submaps)
+			
+			// // // BEGIN ECLIPSE EDIT // // //
+			//Speed up the submap generation system, by giving up if we start running low on sanity.
+			switch(overall_sanity)			//can probably put this to an equation, but also can't really be arsed.
+				if(0 to 15)
+					if(budget < 25)
+						admin_notice("Submap loader giving up at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
+						break
+				if(16 to 30)
+					if(budget < 15)
+						admin_notice("Submap loader giving up at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
+						break
+				if(31 to 45)
+					if(budget < 5)
+						admin_notice("Submap loader giving up at sanity [overall_sanity] with [budget] left to spend.", R_DEBUG)
+						break
+			// // // END ECLIPSE EDIT // // //
 
 		else // We're out of submaps.
 			admin_notice("Submap loader had no submaps to pick from with [budget] left to spend.", R_DEBUG)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -438,17 +438,18 @@
 	if(print_flavor_text())
 		msg += "[print_flavor_text()]<br>"
 
-	// VOREStation Start
-	if(ooc_notes)
-		var/mob/living/carbon/human/F = user
-		if(F.ooc_notes)
-			msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>\n"
-
+	// VOREStation Start		
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Combine OOC note checking and all that into one check. Should help us with the 'ghost examine runtime' issue. Neater, if nothing else. ^Spitzer
 	if(ishuman(user))
 		var/mob/living/carbon/human/F = user
+	
+		if(F.ooc_notes)
+			msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>\n"
 		if(F.species.voracious)
 			msg += "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>\n"
 
+	// // // END ECLIPSE EDITS // // //
 	// VOREStation End
 	msg += "*---------*</span><br>"
 	msg += applying_pressure

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -52,7 +52,7 @@ var/list/ai_verbs_default = list(
 	var/list/connected_robots = list()
 	var/aiRestorePowerRoutine = 0
 	var/viewalerts = 0
-	var/icon/holo_icon//Default is assigned when AI is created.
+	var/icon/holo_icon			//Default is assigned when AI is created.		//Eclipse edit: Whitspace - let's not put comments directly against defines. ^Spitzer
 	var/obj/item/device/pda/ai/aiPDA = null
 	var/obj/item/device/communicator/aiCommunicator = null
 	var/obj/item/device/multitool/aiMulti = null

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -366,7 +366,7 @@ Guard Family
 	
 	if(charge < 100)		//if we're not at full charge, recharge one unit per life cycle
 		if((charge + recharge_rate) > max_charge)	//if one charge cycle puts us over the charge limit, just set us to the limit.
-			charge == max_charge
+			charge = max_charge
 		else
 			charge += recharge_rate
 		

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -364,7 +364,7 @@ Guard Family
 /mob/living/simple_animal/hostile/giant_spider/electric/Life()
 	..()
 	
-	if(charge < 100)		//if we're not at full charge, recharge one unit per life cycle
+	if(charge < max_charge)		//if we're not at full charge, recharge one unit per life cycle
 		if((charge + recharge_rate) > max_charge)	//if one charge cycle puts us over the charge limit, just set us to the limit.
 			charge = max_charge
 		else

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -390,6 +390,15 @@ Guard Family
 	
 	CRASH("Return statement failed to end proc, crashing")
 	
+
+/mob/living/simple_animal/hostile/giant_spider/electric/charged
+	charge = 100		//starts charged and ready to go.
+	//the reason we don't want the Taser spiders to start charged is if a 'ling
+	//grows up to be a Taser spider, we don't want players to immediately get
+	//screwed over by RNGesus. However, there may be a reason to spawn in one
+	//that's already charged (events, testing, etc), so we have a subtype here
+	//just for such an occasion. ^Spitzer
+
 // // // END ECLIPSE EDITS // // //
 /mob/living/simple_animal/hostile/giant_spider/phorogenic
 	desc = "Crystalline and purple, it makes you shudder to look at it. This one has haunting purple eyes."

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -339,8 +339,8 @@ Guard Family
 	icon_dead = "spark_dead"
 	var/max_charge = 100	//Eclipse edit: Total Taser charge.
 	var/charge = 0			//Eclipse edit: Initial Taser charge.
-	var/shot_charge = 5		//Eclipse edit: Charge per shot.
-	var/recharge_rate = 2	//Eclipse edit: Recharge per life() cycle
+	var/shot_charge = 8		//Eclipse edit: Charge per shot.
+	var/recharge_rate = 1.25	//Eclipse edit: Recharge per life() cycle
 
 	maxHealth = 210
 	health = 210

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -337,6 +337,10 @@ Guard Family
 	icon_state = "spark"
 	icon_living = "spark"
 	icon_dead = "spark_dead"
+	var/max_charge = 100	//Eclipse edit: Total Taser charge.
+	var/charge = 0			//Eclipse edit: Initial Taser charge.
+	var/shot_charge = 5		//Eclipse edit: Charge per shot.
+	var/recharge_rate = 2	//Eclipse edit: Recharge per life() cycle
 
 	maxHealth = 210
 	health = 210
@@ -355,6 +359,38 @@ Guard Family
 	poison_per_bite = 3
 	poison_type = "stimm"
 
+// // // BEGIN ECLIPSE EDITS // // //
+// Spiders will now have a finite charge on their Taser tails.
+/mob/living/simple_animal/hostile/giant_spider/electric/Life()
+	..()
+	
+	if(charge < 100)		//if we're not at full charge, recharge one unit per life cycle
+		if((charge + recharge_rate) > max_charge)	//if one charge cycle puts us over the charge limit, just set us to the limit.
+			charge == max_charge
+		else
+			charge += recharge_rate
+		
+	if(charge > shot_charge)		//If our charge is less than that needed to shoot, fall back to beating the shit out of the target.
+		ranged = TRUE
+	else
+		ranged = FALSE
+	
+/mob/living/simple_animal/hostile/giant_spider/electric/ShootTarget()
+	if(charge > shot_charge)		//add that check here too, because we bloody well can
+		ranged = TRUE
+	else
+		ranged = FALSE
+	
+	if(!ranged) 
+		return FALSE
+	else
+		charge -= shot_charge
+		return ..()
+	
+	
+	CRASH("Return statement failed to end proc, crashing")
+	
+// // // END ECLIPSE EDITS // // //
 /mob/living/simple_animal/hostile/giant_spider/phorogenic
 	desc = "Crystalline and purple, it makes you shudder to look at it. This one has haunting purple eyes."
 	tt_desc = "X Brachypelma phorus phorus"

--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -339,8 +339,8 @@ Guard Family
 	icon_dead = "spark_dead"
 	var/max_charge = 100	//Eclipse edit: Total Taser charge.
 	var/charge = 0			//Eclipse edit: Initial Taser charge.
-	var/shot_charge = 8		//Eclipse edit: Charge per shot.
-	var/recharge_rate = 1.25	//Eclipse edit: Recharge per life() cycle
+	var/shot_charge = 12.5		//Eclipse edit: Charge per shot. 8 shots per charge.
+	var/recharge_rate = 2.5	//Eclipse edit: Recharge per life() cycle. 5 cycles per new shot.
 
 	maxHealth = 210
 	health = 210

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 			if(M.flags & MODIFIER_GENETIC)
 				brainmob.add_modifier(M.type)
 
-	if(H.mind)
+	if(H.mind && H.mind.active)			//Eclipse edit: Require mind to be active (ghost can rejoin) before transferring mob.
 		H.mind.transfer_to(brainmob)
 
 	brainmob.languages = H.languages

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -152,27 +152,25 @@
 	name = "Boombase"
 	desc = "What happens when you don't follow SOP."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Boombase.dmm'
-	cost = 12		//Eclipse Edit: Increase cost +10
-	allow_duplicates = TRUE		//Eclipse edit: Explosive craters on the surface hardly seem ill-fitting given Nanotrasen's reason for being here.
+	cost = 2
 
 /datum/map_template/surface/wilderness/deep/BSD
 	name = "Black Shuttle Down"
 	desc = "You REALLY shouldn't be near this."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Blackshuttledown.dmm'
-	cost = 15		//Eclipse edit: Increase cost +5
+	cost = 10
 
 /datum/map_template/surface/wilderness/deep/Rockybase
 	name = "Rocky Base"
 	desc = "A guide to upsetting Icarus and the EIO"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rockybase.dmm'
-	cost = 18		//Eclipse edit: Increase cost +6
+	cost = 12
 
 /datum/map_template/surface/wilderness/deep/MHR
 	name = "Manhack Rock"
 	desc = "A rock filled with nasty Synthetics."
 	mappath = 'maps/submaps/surface_submaps/wilderness/MHR.dmm'
-	cost = 10		//Eclipse edit: Increase cost +8
-	allow_duplicates = TRUE		//Eclipse edit: THEY'RE FILLING THE TUNNELS WITH MANHACKS
+	cost = 2
 
 /datum/map_template/surface/wilderness/normal/GovPatrol
 	name = "Government Patrol"
@@ -190,14 +188,13 @@
 	name = "DoomP"
 	desc = "Witty description here."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DoomP.dmm'
-	cost = 20	//Eclipse edit: Increase cost +10
+	cost = 10
 
 /datum/map_template/surface/wilderness/deep/Cave
 	name = "CaveS"
 	desc = "Chitter chitter!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/CaveS.dmm'
-	cost = 12		//Eclipse edit: Increase cost +6
-	allow_duplicates = TRUE		//Eclipse edit: More spiders? Sure why the hell not
+	cost = 6
 
 /datum/map_template/surface/wilderness/normal/Drugden
 	name = "Drugden"

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -152,33 +152,33 @@
 	name = "Boombase"
 	desc = "What happens when you don't follow SOP."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Boombase.dmm'
-	cost = 2
-	allow_duplicates = TRUE		//Eclipse edit: Set some deep wilderness PoIs to allow multiple spawns, to give the submap loader a break.
+	cost = 12		//Eclipse Edit: Increase cost +10
+	allow_duplicates = TRUE		//Eclipse edit: Explosive craters on the surface hardly seem ill-fitting given Nanotrasen's reason for being here.
 
 /datum/map_template/surface/wilderness/deep/BSD
 	name = "Black Shuttle Down"
 	desc = "You REALLY shouldn't be near this."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Blackshuttledown.dmm'
-	cost = 10
+	cost = 15		//Eclipse edit: Increase cost +5
 
 /datum/map_template/surface/wilderness/deep/Rockybase
 	name = "Rocky Base"
 	desc = "A guide to upsetting Icarus and the EIO"
 	mappath = 'maps/submaps/surface_submaps/wilderness/Rockybase.dmm'
-	cost = 12
+	cost = 18		//Eclipse edit: Increase cost +6
 
 /datum/map_template/surface/wilderness/deep/MHR
 	name = "Manhack Rock"
 	desc = "A rock filled with nasty Synthetics."
 	mappath = 'maps/submaps/surface_submaps/wilderness/MHR.dmm'
-	cost = 2
+	cost = 10		//Eclipse edit: Increase cost +8
+	allow_duplicates = TRUE		//Eclipse edit: THEY'RE FILLING THE TUNNELS WITH MANHACKS
 
 /datum/map_template/surface/wilderness/normal/GovPatrol
 	name = "Government Patrol"
 	desc = "A long lost SifGuard ground survey patrol. Now they have you guys!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/GovPatrol.dmm'
 	cost = 1
-	allow_duplicates = TRUE		//Eclipse edit: no people, just a gun and some supplies.
 
 /datum/map_template/surface/wilderness/normal/DecoupledEngine
 	name = "Decoupled Engine"
@@ -190,13 +190,13 @@
 	name = "DoomP"
 	desc = "Witty description here."
 	mappath = 'maps/submaps/surface_submaps/wilderness/DoomP.dmm'
-	cost = 10
+	cost = 20	//Eclipse edit: Increase cost +10
 
 /datum/map_template/surface/wilderness/deep/Cave
 	name = "CaveS"
 	desc = "Chitter chitter!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/CaveS.dmm'
-	cost = 6
+	cost = 12		//Eclipse edit: Increase cost +6
 	allow_duplicates = TRUE		//Eclipse edit: More spiders? Sure why the hell not
 
 /datum/map_template/surface/wilderness/normal/Drugden
@@ -204,7 +204,6 @@
 	desc = "The remains of ill thought out whims."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Drugden.dmm'
 	cost = 6
-	allow_duplicates = TRUE		//Eclipse edit: ALL the drugs!
 
 /datum/map_template/surface/wilderness/normal/Musk
 	name = "Musk"

--- a/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -153,6 +153,7 @@
 	desc = "What happens when you don't follow SOP."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Boombase.dmm'
 	cost = 2
+	allow_duplicates = TRUE		//Eclipse edit: Set some deep wilderness PoIs to allow multiple spawns, to give the submap loader a break.
 
 /datum/map_template/surface/wilderness/deep/BSD
 	name = "Black Shuttle Down"
@@ -177,6 +178,7 @@
 	desc = "A long lost SifGuard ground survey patrol. Now they have you guys!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/GovPatrol.dmm'
 	cost = 1
+	allow_duplicates = TRUE		//Eclipse edit: no people, just a gun and some supplies.
 
 /datum/map_template/surface/wilderness/normal/DecoupledEngine
 	name = "Decoupled Engine"
@@ -195,12 +197,14 @@
 	desc = "Chitter chitter!"
 	mappath = 'maps/submaps/surface_submaps/wilderness/CaveS.dmm'
 	cost = 6
+	allow_duplicates = TRUE		//Eclipse edit: More spiders? Sure why the hell not
 
 /datum/map_template/surface/wilderness/normal/Drugden
 	name = "Drugden"
 	desc = "The remains of ill thought out whims."
 	mappath = 'maps/submaps/surface_submaps/wilderness/Drugden.dmm'
 	cost = 6
+	allow_duplicates = TRUE		//Eclipse edit: ALL the drugs!
 
 /datum/map_template/surface/wilderness/normal/Musk
 	name = "Musk"

--- a/modular_eclipse/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/modular_eclipse/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -2,53 +2,10 @@
 // This is so Travis can validate PoIs, and ensure future changes don't break PoIs, as PoIs are loaded at runtime and the compiler can't catch errors.
 // When adding a new PoI, please add it to this list.
 #if MAP_TEST
-/*#include "spider1.dmm"
-#include "Flake.dmm"	//Eclipse Edit: The duplicate entries are left here but commented for more convenient reference when making new areas
-#include "MCamp1.dmm"
-#include "Rocky1.dmm"
-#include "Rocky2.dmm"
-#include "Rocky3.dmm"
-#include "Shack1.dmm"
-#include "Smol1.dmm"
-#include "Mudpit.dmm"
-#include "Snowrock1.dmm"
-#include "Boombase.dmm"
-#include "Blackshuttledown.dmm"
-#include "Lab1.dmm"
-#include "Rocky4.dmm"
-#include "DJOutpost1.dmm"
-#include "DJOutpost2.dmm"
-#include "Rockybase.dmm"
-#include "MHR.dmm"
-#include "GovPatrol.dmm"
-#include "DecoupledEngine.dmm"
-#include "DoomP.dmm"
-#include "CaveS.dmm"
-#include "Drugden.dmm"
-#include "Musk.dmm"
-#include "Manor1.dmm"
-#include "Junkyard1.dmm"*/ //Broken.
+
 #include "Hunted.dmm"
 
 #endif
-
-// The 'wilderness' is the endgame for Explorers. Extremely dangerous and far away from help, but with vast shinies.
-// POIs here spawn in two different sections, the top half and bottom half of the map.
-// The top half connects to the outpost z-level, and is separated from the bottom half by a river. It should provide a challenge to a well equipped Explorer team.
-// The bottom half should be even more dangerous, where only the robust, fortunate, or lucky can survive.
-
-///datum/map_template/surface/wilderness
-//	name = "Surface Content - Wildy"
-//	desc = "Used to make the surface's wilderness be 17% less boring."
-
-// 'Normal' templates get used on the top half, and should be challenging.
-//datum/map_template/surface/wilderness/normal
-
-// 'Deep' templates get used on the bottom half, and should be (even more) dangerous and rewarding.
-//datum/map_template/surface/wilderness/deep
-
-// To be added: Templates for surface exploration when they are made.
-
 
 /datum/map_template/surface/wilderness/normal/Hunted
 	name = "Hunted"
@@ -58,165 +15,31 @@
 	annihilate = TRUE
 	cost = 20
 
-/*/datum/map_template/surface/wilderness/normal/spider1
-	name = "Spider Nest 1"
-	desc = "A small spider nest, in the forest."
-	mappath = 'maps/submaps/surface_submaps/wilderness/spider1.dmm'
+//Rebalancing, done by Spitzer
+//Clearing-area submaps
+/datum/map_template/surface/wilderness/normal/spider1
 	allow_duplicates = TRUE
-	cost = 5
+	cost = 5		//Increase cost +4; spiders are fun and all but this is light woods and we're going to get spammed with spiders otherwise
 
-/datum/map_template/surface/wilderness/normal/Flake
-	name = "Forest Lake"
-	desc = "A serene lake sitting amidst the surface."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Flake.dmm'
-	cost = 10
-
-/datum/map_template/surface/wilderness/normal/Mcamp1
-	name = "Military Camp 1"
-	desc = "A derelict military camp host to some unsavory dangers"
-	mappath = 'maps/submaps/surface_submaps/wilderness/MCamp1.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Mudpit
-	name = "Mudpit"
-	desc = "What happens when someone is a bit too careless with gas.."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Mudpit.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Rocky1
-	name = "Rocky1"
-	desc = "DununanununanununuNAnana"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky1.dmm'
-	allow_duplicates = TRUE
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Rocky2
-	name =  "Rocky2"
-	desc = "More rocks."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky2.dmm'
-	allow_duplicates = TRUE
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Rocky3
-	name = "Rocky3"
-	desc = "More and more and more rocks."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky3.dmm'
-	desc = "DununanununanununuNAnana"
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Shack1
-	name = "Shack1"
-	desc = "A small shack in the middle of nowhere, Your halloween murder happens here"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Shack1.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Smol1
-	name = "Smol1"
-	desc = "A tiny grove of trees, The Nemesis of thicc"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Smol1.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Snowrock1
-	name = "Snowrock1"
-	desc = "A rocky snow covered area"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Snowrock1.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Cragzone1
-	name = "Cragzone1"
-	desc = "Rocks and more rocks."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Cragzone1.dmm'
-	cost = 5
-	allow_duplicates = TRUE
-
-/datum/map_template/surface/wilderness/normal/Lab1
-	name = "Lab1"
-	desc = "An isolated small robotics lab."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Lab1.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/Rocky4
-	name = "Rocky4"
-	desc = "An interesting geographic formation."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Rocky4.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/deep/DJOutpost1
-	name = "DJOutpost1"
-	desc = "Home of Sif Free Radio, the best - and only - radio station for miles around."
-	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost1.dmm'
-	template_group = "Sif Free Radio"
-	cost = 5
-
-/datum/map_template/surface/wilderness/deep/DJOutpost2
-	name = "DJOutpost2"
-	desc = "The cratered remains of Sif Free Radio, the best - and only - radio station for miles around."
-	mappath = 'maps/submaps/surface_submaps/wilderness/DJOutpost2.dmm'
-	template_group = "Sif Free Radio"
-	cost = 5
-
+//deep woods
 /datum/map_template/surface/wilderness/deep/Boombase
-	name = "Boombase"
-	desc = "What happens when you don't follow SOP."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Boombase.dmm'
-	cost = 5
+	cost = 8		//Increase cost +6
+	allow_duplicates = TRUE		//Explosive craters on the surface hardly seem ill-fitting given Nanotrasen's reason for being here.
 
 /datum/map_template/surface/wilderness/deep/BSD
-	name = "Black Shuttle Down"
-	desc = "You REALLY shouldn't be near this."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Blackshuttledown.dmm'
-	cost = 30
+	cost = 12		//Increase cost +2
 
 /datum/map_template/surface/wilderness/deep/Rockybase
-	name = "Rocky Base"
-	desc = "A guide to upsetting Icarus and the EIO"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Rockybase.dmm'
-	cost = 35
-
+	cost = 15		//Increase cost +3
+	
 /datum/map_template/surface/wilderness/deep/MHR
-	name = "Manhack Rock"
-	desc = "A rock filled with nasty Synthetics."
-	mappath = 'maps/submaps/surface_submaps/wilderness/MHR.dmm'
-	cost = 15
-
-/datum/map_template/surface/wilderness/normal/GovPatrol
-	name = "Government Patrol"
-	desc = "A long lost SifGuard ground survey patrol. Now they have you guys!"
-	mappath = 'maps/submaps/surface_submaps/wilderness/GovPatrol.dmm'
-	cost = 5
-
-/datum/map_template/surface/wilderness/normal/DecoupledEngine
-	name = "Decoupled Engine"
-	desc = "A damaged fission engine jettisoned from a starship long ago."
-	mappath = 'maps/submaps/surface_submaps/wilderness/DecoupledEngine.dmm'
-	cost = 15
+	cost = 8		//Increase cost +6
+	allow_duplicates = TRUE		//THEY'RE FILLING THE TUNNELS WITH MANHACKS
 
 /datum/map_template/surface/wilderness/deep/DoomP
-	name = "DoomP"
-	desc = "Witty description here."
-	mappath = 'maps/submaps/surface_submaps/wilderness/DoomP.dmm'
-	cost = 30
+	cost = 20	//Increase cost +10
 
 /datum/map_template/surface/wilderness/deep/Cave
-	name = "CaveS"
-	desc = "Chitter chitter!"
-	mappath = 'maps/submaps/surface_submaps/wilderness/CaveS.dmm'
-	cost = 20
+	cost = 12		//Increase cost +6
+	allow_duplicates = TRUE		//More spiders? Sure why the hell not
 
-/datum/map_template/surface/wilderness/normal/Drugden
-	name = "Drugden"
-	desc = "The remains of ill thought out whims."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Drugden.dmm'
-	cost = 20
-
-/datum/map_template/surface/wilderness/normal/Musk
-	name = "Musk"
-	desc = "0 to 60 in 1.9 seconds."
-	mappath = 'maps/submaps/surface_submaps/wilderness/Musk.dmm'
-	cost = 10
-
-/datum/map_template/surface/wilderness/deep/Manor1
-	name = "Manor1"
-	desc = "Whodunit"
-	mappath = 'maps/submaps/surface_submaps/wilderness/Manor1.dmm'
-	cost = 20*/

--- a/modular_eclipse/maps/submaps/surface_submaps/wilderness/wilderness.dm
+++ b/modular_eclipse/maps/submaps/surface_submaps/wilderness/wilderness.dm
@@ -19,7 +19,7 @@
 //Clearing-area submaps
 /datum/map_template/surface/wilderness/normal/spider1
 	allow_duplicates = TRUE
-	cost = 5		//Increase cost +4; spiders are fun and all but this is light woods and we're going to get spammed with spiders otherwise
+	cost = 5		//Increase cost +4; spiders are fun and all, but this is light woods and we're going to get spammed with spiders otherwise
 
 //deep woods
 /datum/map_template/surface/wilderness/deep/Boombase
@@ -27,7 +27,7 @@
 	allow_duplicates = TRUE		//Explosive craters on the surface hardly seem ill-fitting given Nanotrasen's reason for being here.
 
 /datum/map_template/surface/wilderness/deep/BSD
-	cost = 12		//Increase cost +2
+	cost = 10		//No change. Might go back and do more later, so leaving it in.
 
 /datum/map_template/surface/wilderness/deep/Rockybase
 	cost = 15		//Increase cost +3
@@ -40,6 +40,6 @@
 	cost = 20	//Increase cost +10
 
 /datum/map_template/surface/wilderness/deep/Cave
-	cost = 12		//Increase cost +6
+	cost = 10		//Increase cost +4
 	allow_duplicates = TRUE		//More spiders? Sure why the hell not
 


### PR DESCRIPTION
Assorted fixes to the code, from what I can see on the `nt-dept-dispatcher` branch.

:cl: EvilJackCarver
🔧 Adds more nullchecks to the supply crate ordering (#200)
🔧 Beacon sprites now function as intended (#243)
🔧 Brain surgery now shouldn't pull the person to the brain if the mind can't be cloned (#184)
🔧 Wilderness submap loader can now spawn more than one of some of Sif's deep-woods stuff. (#248)
🔧 Tweak to examine code. (#241)
🛠 Tweaks to Github tooling
➕ Adds a recharge mechanic to Taser spiders. It's in beta.
/:cl:

CLOSES #248 
CLOSES #243 AS FIXED
CLOSES #241 AS FIXED
CLOSES #200 AS FIXED
PATCHES #184 FOR BRAIN SURGERY, DOES NOT FIX MAIN ISSUE