### PR TITLE
Patch for antag selection

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -126,6 +126,13 @@
 			candidates -= player
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist! They have been removed from the draft.")
 
+		// // // BEGIN ECLIPSE EDITS // // //
+		//Midround antag.
+		else if(player.assigned_role in restricted_jobs)
+			candidates -= player
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: Their job is incompatible with this role! They have been removed from the draft.")
+		// // // END ECLIPSE EDITS // // //
+
 	return candidates
 
 /datum/antagonist/proc/attempt_random_spawn()
@@ -186,6 +193,12 @@
 	if(!(flags & ANTAG_OVERRIDE_JOB) && (!player.current || istype(player.current, /mob/new_player)))
 		log_debug("[player.key] was selected for [role_text] by lottery, but they have not joined the game.")
 		return 0
+	// // // BEGIN ECLIPSE EDIT // // //
+	//Adds checks against midround antagonists in the job restrictions.
+	if(player.assigned_role in restricted_jobs)
+		log_debug("[player.key] was selected for [role_text] by lottery, but their occupation datum is incompatible with the role.")
+		return 0
+	// // // END ECLIPSE EDIT // // //
 
 	pending_antagonists |= player
 	log_debug("[player.key] has been selected for [role_text] by lottery.")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -191,6 +191,8 @@ var/global/list/additional_antag_types = list()
 		//antag roles that replace jobs need to be assigned before the job controller hands out jobs.
 		if(antag.flags & ANTAG_OVERRIDE_JOB)
 			antag.attempt_spawn() //select antags to be spawned
+		
+		//antag.attempt_spawn()	//Eclipse edit - weh. Attempting this only causes it to claim not enough players were readied for the round.
 
 ///post_setup()
 /datum/game_mode/proc/post_setup()

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -70,6 +70,12 @@ var/global/datum/controller/occupations/job_master
 				return 0
 			if(!is_job_whitelisted(player, rank)) //VOREStation Code
 				return 0
+			// // // BEGIN ECLIPSE EDIT // // //
+			//More checks for antag status
+			if(player.mind && player.mind.special_role)		//are we antagonist?
+				if(job in player.mind.antag_job_restrictions)			//Is our role in the antag restricted jobs?
+					return 0
+			// // // END ECLIPSE EDIT // // //
 
 			var/position_limit = job.total_positions
 			if(!latejoin)
@@ -151,6 +157,14 @@ var/global/datum/controller/occupations/job_master
 				Debug("GRJ player not whitelisted for this job, Player: [player], Job: [job.title]")
 				continue
 			//VOREStation Code End
+
+			// // // BEGIN ECLIPSE EDIT // // //
+			//More checks for antag status
+			if(player.mind && player.mind.special_role)		//are we antagonist?
+				if(job in player.mind.antag_job_restrictions)			//Is our role in the antag restricted jobs?
+					Debug("GRJ incompatible with antagonist role, Player: [player], Job: [job.title], Antag: [player.mind.special_role]")
+					continue
+			// // // END ECLIPSE EDIT // // //
 
 			if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 				Debug("GRJ Random job given, Player: [player], Job: [job]")
@@ -297,7 +311,7 @@ var/global/datum/controller/occupations/job_master
 						Debug("DO player not old enough, Player: [player], Job:[job.title]")
 						continue
 
-					// // // BEGIN ECLIPSE EDIT // // //
+					// // // BEGIN ECLIPSE EDITS // // //
 					/*
 					 * Theoretically fixes an issue where a player could join as a whitelisted job if it was selected before
 					 * the whitelist made them unable to select it. This only denies them the ability to spawn as the job, it
@@ -306,7 +320,13 @@ var/global/datum/controller/occupations/job_master
 					if(!is_job_whitelisted(player, job.title))
 						Debug("DO player not whitelisted for this job, Player: [player], Job: [job.title]")
 						continue
-					// // // END ECLIPSE EDIT // // //
+					
+					//More checks for antag status
+					if(player.mind && player.mind.special_role)		//are we antagonist?
+						if(job in player.mind.antag_job_restrictions)			//Is our role in the antag restricted jobs?
+							Debug("DO incompatible with antagonist role, Player: [player], Job: [job.title], Antag: [player.mind.special_role]")
+							continue
+					// // // END ECLIPSE EDITS // // //
 
 					// If the player wants that job on this level, then try give it to him.
 					if(player.client.prefs.GetJobDepartment(job, level) & job.flag)


### PR DESCRIPTION
Nestor, I'll let you decide whether this gets through the code freeze as a "bugfix or critical patch", or if it falls afoul and is gonna need to wait til the freeze is over.

:cl: EvilJackCarver
fix: Patches antag selection. Antag selection now has more checks that should prevent it from drafting protected rounds.
/:cl:

Can't really do much testing in dev without more people in my dev server, and I really don't feel up for that.

### What still needs to be done

In cases where antag status is independent of job (e.g. traitor, changeling), job selection takes priority over antag selection still. This means there may come an issue where you will have an empty traitor round because the only guy that's got it enabled is security.

I'm posting what I have. I'm beat down and tired.

PAtches #264, does not entirely fix.